### PR TITLE
Use seeds to get deterministic behavior in unit tests and examples

### DIFF
--- a/data/examples/ap1rog/external_hamiltonian_h2_cholesky.py
+++ b/data/examples/ap1rog/external_hamiltonian_h2_cholesky.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from horton import *
+from horton.test.common import numpy_seed
 
 # Read Hamiltonian from file 'h2_hamiltonian.h5'
 # ----------------------------------------------
@@ -20,4 +21,5 @@ orb.assign(olp)
 # Do OO-AP1roG optimization
 # -------------------------
 ap1rog = RAp1rog(mol.lf, occ_model)
-energy, c, l = ap1rog(mol.one_mo, mol.two_mo, mol.core_energy, orb, olp, True)
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energy, c, l = ap1rog(mol.one_mo, mol.two_mo, mol.core_energy, orb, olp, True)

--- a/data/examples/ap1rog/external_hamiltonian_n2_dense.py
+++ b/data/examples/ap1rog/external_hamiltonian_n2_dense.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from horton import *
+from horton.test.common import numpy_seed
 
 # Read Hamiltonian from file 'FCIDUMP'
 # ------------------------------------
@@ -20,4 +21,5 @@ orb.assign(olp)
 # Do OO-AP1roG optimization
 # -------------------------
 ap1rog = RAp1rog(mol.lf, occ_model)
-energy, c, l = ap1rog(mol.one_mo, mol.two_mo, mol.core_energy, orb, olp, True)
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energy, c, l = ap1rog(mol.one_mo, mol.two_mo, mol.core_energy, orb, olp, True)

--- a/data/examples/ap1rog/external_hamiltonian_water_dense.py
+++ b/data/examples/ap1rog/external_hamiltonian_water_dense.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from horton import *
+from horton.test.common import numpy_seed
 
 # Read Hamiltonian from file 'water_hamiltonian.h5'
 # -------------------------------------------------
@@ -20,4 +21,5 @@ orb.assign(olp)
 # Do OO-AP1roG optimization
 # -------------------------
 ap1rog = RAp1rog(mol.lf, occ_model)
-energy, c, l = ap1rog(mol.one_mo, mol.two_mo, mol.core_energy, orb, olp, True)
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energy, c, l = ap1rog(mol.one_mo, mol.two_mo, mol.core_energy, orb, olp, True)

--- a/data/examples/ap1rog/h2_cholesky_3-21g.py
+++ b/data/examples/ap1rog/h2_cholesky_3-21g.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
-from horton import *
 import numpy as np
+
+from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -50,22 +52,22 @@ one.iadd(na)
 ## Do OO-AP1roG optimization ##################################################
 ###############################################################################
 ap1rog = RAp1rog(lf, occ_model)
-energy, c, l = ap1rog(one, er, external['nn'], orb, olp, True, **{
-    'indextrans': 'tensordot',
-    'warning': False,
-    'checkpoint': 1,
-    'levelshift': 1e-8,
-    'absolute': False,
-    'givensrot': np.array([[]]),
-    'swapa': np.array([[]]),
-    'sort': True,
-    'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
-    'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
-    'maxiter': {'wfniter': 200, 'orbiter': 100},
-    'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
-    'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
-    'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
-    'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
-    'orbitaloptimizer': 'variational'
-}
-)
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energy, c, l = ap1rog(one, er, external['nn'], orb, olp, True, **{
+        'indextrans': 'tensordot',
+        'warning': False,
+        'checkpoint': 1,
+        'levelshift': 1e-8,
+        'absolute': False,
+        'givensrot': np.array([[]]),
+        'swapa': np.array([[]]),
+        'sort': True,
+        'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
+        'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
+        'maxiter': {'wfniter': 200, 'orbiter': 100},
+        'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
+        'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
+        'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
+        'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
+        'orbitaloptimizer': 'variational'
+    })

--- a/data/examples/ap1rog/h2_cholesky_aug-cc-pvdz.py
+++ b/data/examples/ap1rog/h2_cholesky_aug-cc-pvdz.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
-from horton import *
 import numpy as np
+
+from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -50,22 +52,22 @@ one.iadd(na)
 ## Do OO-AP1roG optimization ##################################################
 ###############################################################################
 ap1rog = RAp1rog(lf, occ_model)
-energy, c, l = ap1rog(one, er, external['nn'], orb, olp, True, **{
-    'indextrans': 'tensordot',
-    'warning': False,
-    'checkpoint': 1,
-    'levelshift': 1e-8,
-    'absolute': False,
-    'givensrot': np.array([[]]),
-    'swapa': np.array([[]]),
-    'sort': True,
-    'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
-    'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
-    'maxiter': {'wfniter': 200, 'orbiter': 100},
-    'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
-    'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
-    'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
-    'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
-    'orbitaloptimizer': 'variational'
-}
-)
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energy, c, l = ap1rog(one, er, external['nn'], orb, olp, True, **{
+        'indextrans': 'tensordot',
+        'warning': False,
+        'checkpoint': 1,
+        'levelshift': 1e-8,
+        'absolute': False,
+        'givensrot': np.array([[]]),
+        'swapa': np.array([[]]),
+        'sort': True,
+        'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
+        'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
+        'maxiter': {'wfniter': 200, 'orbiter': 100},
+        'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
+        'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
+        'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
+        'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
+        'orbitaloptimizer': 'variational'
+    })

--- a/data/examples/ap1rog/h2_cholesky_cc-pvdz.py
+++ b/data/examples/ap1rog/h2_cholesky_cc-pvdz.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
-from horton import *
 import numpy as np
+
+from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -50,22 +52,22 @@ one.iadd(na)
 ## Do OO-AP1roG optimization ##################################################
 ###############################################################################
 ap1rog = RAp1rog(lf, occ_model)
-energy, c, l = ap1rog(one, er, external['nn'], orb, olp, True, **{
-    'indextrans': 'tensordot',
-    'warning': False,
-    'checkpoint': 1,
-    'levelshift': 1e-8,
-    'absolute': False,
-    'givensrot': np.array([[]]),
-    'swapa': np.array([[]]),
-    'sort': True,
-    'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
-    'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
-    'maxiter': {'wfniter': 200, 'orbiter': 100},
-    'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
-    'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
-    'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
-    'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
-    'orbitaloptimizer': 'variational'
-}
-)
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energy, c, l = ap1rog(one, er, external['nn'], orb, olp, True, **{
+        'indextrans': 'tensordot',
+        'warning': False,
+        'checkpoint': 1,
+        'levelshift': 1e-8,
+        'absolute': False,
+        'givensrot': np.array([[]]),
+        'swapa': np.array([[]]),
+        'sort': True,
+        'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
+        'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
+        'maxiter': {'wfniter': 200, 'orbiter': 100},
+        'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
+        'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
+        'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
+        'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
+        'orbitaloptimizer': 'variational'
+    })

--- a/data/examples/ap1rog/h2_dense_3-21g.py
+++ b/data/examples/ap1rog/h2_dense_3-21g.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
-from horton import *
 import numpy as np
+
+from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -50,22 +52,22 @@ one.iadd(na)
 ## Do OO-AP1roG optimization ##################################################
 ###############################################################################
 ap1rog = RAp1rog(lf, occ_model)
-energy, c, l = ap1rog(one, er, external['nn'], orb, olp, True, **{
-    'indextrans': 'tensordot',
-    'warning': False,
-    'checkpoint': 1,
-    'levelshift': 1e-8,
-    'absolute': False,
-    'givensrot': np.array([[]]),
-    'swapa': np.array([[]]),
-    'sort': True,
-    'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
-    'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
-    'maxiter': {'wfniter': 200, 'orbiter': 100},
-    'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
-    'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
-    'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
-    'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
-    'orbitaloptimizer': 'variational'
-}
-)
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energy, c, l = ap1rog(one, er, external['nn'], orb, olp, True, **{
+        'indextrans': 'tensordot',
+        'warning': False,
+        'checkpoint': 1,
+        'levelshift': 1e-8,
+        'absolute': False,
+        'givensrot': np.array([[]]),
+        'swapa': np.array([[]]),
+        'sort': True,
+        'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
+        'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
+        'maxiter': {'wfniter': 200, 'orbiter': 100},
+        'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
+        'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
+        'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
+        'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
+        'orbitaloptimizer': 'variational'
+    })

--- a/data/examples/ap1rog/h2_dense_aug-cc-pvdz.py
+++ b/data/examples/ap1rog/h2_dense_aug-cc-pvdz.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
-from horton import *
 import numpy as np
+
+from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -50,22 +52,22 @@ one.iadd(na)
 ## Do OO-AP1roG optimization ##################################################
 ###############################################################################
 ap1rog = RAp1rog(lf, occ_model)
-energy, c, l = ap1rog(one, er, external['nn'], orb, olp, True, **{
-    'indextrans': 'tensordot',
-    'warning': False,
-    'checkpoint': 1,
-    'levelshift': 1e-8,
-    'absolute': False,
-    'givensrot': np.array([[]]),
-    'swapa': np.array([[]]),
-    'sort': True,
-    'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
-    'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
-    'maxiter': {'wfniter': 200, 'orbiter': 100},
-    'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
-    'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
-    'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
-    'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
-    'orbitaloptimizer': 'variational'
-}
-)
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energy, c, l = ap1rog(one, er, external['nn'], orb, olp, True, **{
+        'indextrans': 'tensordot',
+        'warning': False,
+        'checkpoint': 1,
+        'levelshift': 1e-8,
+        'absolute': False,
+        'givensrot': np.array([[]]),
+        'swapa': np.array([[]]),
+        'sort': True,
+        'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
+        'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
+        'maxiter': {'wfniter': 200, 'orbiter': 100},
+        'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
+        'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
+        'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
+        'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
+        'orbitaloptimizer': 'variational'
+    })

--- a/data/examples/ap1rog/h2_dense_cc-pvdz.py
+++ b/data/examples/ap1rog/h2_dense_cc-pvdz.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
-from horton import *
 import numpy as np
+
+from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -50,22 +52,22 @@ one.iadd(na)
 ## Do OO-AP1roG optimization ##################################################
 ###############################################################################
 ap1rog = RAp1rog(lf, occ_model)
-energy, c, l = ap1rog(one, er, external['nn'], orb, olp, True, **{
-    'indextrans': 'tensordot',
-    'warning': False,
-    'checkpoint': 1,
-    'levelshift': 1e-8,
-    'absolute': False,
-    'givensrot': np.array([[]]),
-    'swapa': np.array([[]]),
-    'sort': True,
-    'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
-    'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
-    'maxiter': {'wfniter': 200, 'orbiter': 100},
-    'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
-    'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
-    'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
-    'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
-    'orbitaloptimizer': 'variational'
-}
-)
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energy, c, l = ap1rog(one, er, external['nn'], orb, olp, True, **{
+        'indextrans': 'tensordot',
+        'warning': False,
+        'checkpoint': 1,
+        'levelshift': 1e-8,
+        'absolute': False,
+        'givensrot': np.array([[]]),
+        'swapa': np.array([[]]),
+        'sort': True,
+        'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
+        'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
+        'maxiter': {'wfniter': 200, 'orbiter': 100},
+        'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
+        'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
+        'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
+        'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
+        'orbitaloptimizer': 'variational'
+    })

--- a/data/examples/ap1rog/hubbard.py
+++ b/data/examples/ap1rog/hubbard.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 
+import numpy as np
+
 from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Define Occupation model, expansion coefficients and overlap ################
@@ -37,4 +40,5 @@ scf_solver(ham, lf, olp, occ_model, orb)
 ## Do OO-AP1roG optimization ##################################################
 ###############################################################################
 ap1rog = RAp1rog(lf, occ_model)
-energy, c, l = ap1rog(kin, two, 0, orb, olp, True)
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energy, c, l = ap1rog(kin, two, 0, orb, olp, True)

--- a/data/examples/ap1rog/restart_water_cholesky_3-21g.py
+++ b/data/examples/ap1rog/restart_water_cholesky_3-21g.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
+
 from horton import *
+from horton.test.common import numpy_seed
 
 # Set up molecule, define basis set
 # ---------------------------------
@@ -39,4 +41,5 @@ project_orbitals_ortho(old.olp, olp, old.exp_alpha, exp_alpha)
 # Do OO-AP1roG optimization
 # -------------------------
 ap1rog = RAp1rog(lf, occ_model)
-energy, g, l = ap1rog(one, two, core_energy, exp_alpha, olp, True)
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energy, g, l = ap1rog(one, two, core_energy, exp_alpha, olp, True)

--- a/data/examples/ap1rog/water_cholesky_3-21g.py
+++ b/data/examples/ap1rog/water_cholesky_3-21g.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
-from horton import *
 import numpy as np
+
+from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -50,22 +52,22 @@ one.iadd(na)
 ## Do OO-AP1roG optimization ##################################################
 ###############################################################################
 ap1rog = RAp1rog(lf, occ_model)
-energy, c, l = ap1rog(one, er, external['nn'], orb, olp, True, **{
-    'indextrans': 'tensordot',
-    'warning': False,
-    'checkpoint': 1,
-    'levelshift': 1e-8,
-    'absolute': False,
-    'givensrot': np.array([[]]),
-    'swapa': np.array([[]]),
-    'sort': True,
-    'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
-    'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
-    'maxiter': {'wfniter': 200, 'orbiter': 100},
-    'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
-    'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
-    'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
-    'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
-    'orbitaloptimizer': 'variational'
-}
-)
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energy, c, l = ap1rog(one, er, external['nn'], orb, olp, True, **{
+        'indextrans': 'tensordot',
+        'warning': False,
+        'checkpoint': 1,
+        'levelshift': 1e-8,
+        'absolute': False,
+        'givensrot': np.array([[]]),
+        'swapa': np.array([[]]),
+        'sort': True,
+        'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
+        'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
+        'maxiter': {'wfniter': 200, 'orbiter': 100},
+        'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
+        'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
+        'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
+        'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
+        'orbitaloptimizer': 'variational'
+    })

--- a/data/examples/ap1rog/water_cholesky_cc-pvdz.py
+++ b/data/examples/ap1rog/water_cholesky_cc-pvdz.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
-from horton import *
 import numpy as np
+
+from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -49,22 +51,22 @@ one.iadd(na)
 ## Do OO-AP1roG optimization ##################################################
 ###############################################################################
 ap1rog = RAp1rog(lf, occ_model)
-energy, c, l = ap1rog(one, er, external['nn'], orb, olp, True, **{
-    'indextrans': 'tensordot',
-    'warning': False,
-    'checkpoint': 1,
-    'levelshift': 1e-8,
-    'absolute': False,
-    'givensrot': np.array([[]]),
-    'swapa': np.array([[]]),
-    'sort': True,
-    'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
-    'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
-    'maxiter': {'wfniter': 200, 'orbiter': 100},
-    'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
-    'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
-    'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
-    'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
-    'orbitaloptimizer': 'variational'
-}
-)
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energy, c, l = ap1rog(one, er, external['nn'], orb, olp, True, **{
+        'indextrans': 'tensordot',
+        'warning': False,
+        'checkpoint': 1,
+        'levelshift': 1e-8,
+        'absolute': False,
+        'givensrot': np.array([[]]),
+        'swapa': np.array([[]]),
+        'sort': True,
+        'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
+        'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
+        'maxiter': {'wfniter': 200, 'orbiter': 100},
+        'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
+        'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
+        'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
+        'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
+        'orbitaloptimizer': 'variational'
+    })

--- a/data/examples/ap1rog/water_cholesky_sto-3g.py
+++ b/data/examples/ap1rog/water_cholesky_sto-3g.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
-from horton import *
 import numpy as np
+
+from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -49,22 +51,22 @@ one.iadd(na)
 ## Do OO-AP1roG optimization ##################################################
 ###############################################################################
 ap1rog = RAp1rog(lf, occ_model)
-energy, c, l = ap1rog(one, er, external['nn'], orb, olp, True, **{
-    'indextrans': 'tensordot',
-    'warning': False,
-    'checkpoint': 1,
-    'levelshift': 1e-8,
-    'absolute': False,
-    'givensrot': np.array([[]]),
-    'swapa': np.array([[]]),
-    'sort': True,
-    'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
-    'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
-    'maxiter': {'wfniter': 200, 'orbiter': 100},
-    'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
-    'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
-    'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
-    'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
-    'orbitaloptimizer': 'variational'
-}
-)
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energy, c, l = ap1rog(one, er, external['nn'], orb, olp, True, **{
+        'indextrans': 'tensordot',
+        'warning': False,
+        'checkpoint': 1,
+        'levelshift': 1e-8,
+        'absolute': False,
+        'givensrot': np.array([[]]),
+        'swapa': np.array([[]]),
+        'sort': True,
+        'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
+        'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
+        'maxiter': {'wfniter': 200, 'orbiter': 100},
+        'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
+        'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
+        'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
+        'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
+        'orbitaloptimizer': 'variational'
+    })

--- a/data/examples/ap1rog/water_default.py
+++ b/data/examples/ap1rog/water_default.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
-from horton import *
 import numpy as np
+
+from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -50,22 +52,22 @@ one.iadd(na)
 ## Do OO-AP1roG optimization ##################################################
 ###############################################################################
 ap1rog = RAp1rog(lf, occ_model)
-energy, c, l = ap1rog(one, two, external['nn'], orb, olp, True, **{
-    'indextrans': 'tensordot',
-    'warning': False,
-    'checkpoint': 1,
-    'levelshift': 1e-8,
-    'absolute': False,
-    'givensrot': np.array([[]]),
-    'swapa': np.array([[]]),
-    'sort': True,
-    'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
-    'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
-    'maxiter': {'wfniter': 200, 'orbiter': 100},
-    'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
-    'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
-    'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
-    'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
-    'orbitaloptimizer': 'variational'
-}
-)
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energy, c, l = ap1rog(one, two, external['nn'], orb, olp, True, **{
+        'indextrans': 'tensordot',
+        'warning': False,
+        'checkpoint': 1,
+        'levelshift': 1e-8,
+        'absolute': False,
+        'givensrot': np.array([[]]),
+        'swapa': np.array([[]]),
+        'sort': True,
+        'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
+        'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
+        'maxiter': {'wfniter': 200, 'orbiter': 100},
+        'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
+        'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
+        'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
+        'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
+        'orbitaloptimizer': 'variational'
+    })

--- a/data/examples/ap1rog/water_dense_3-21g.py
+++ b/data/examples/ap1rog/water_dense_3-21g.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
-from horton import *
 import numpy as np
+
+from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -49,22 +51,22 @@ one.iadd(na)
 ## Do OO-AP1roG optimization ##################################################
 ###############################################################################
 ap1rog = RAp1rog(lf, occ_model)
-energy, c, l = ap1rog(one, er, external['nn'], orb, olp, True, **{
-    'indextrans': 'tensordot',
-    'warning': False,
-    'checkpoint': 1,
-    'levelshift': 1e-8,
-    'absolute': False,
-    'givensrot': np.array([[]]),
-    'swapa': np.array([[]]),
-    'sort': True,
-    'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
-    'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
-    'maxiter': {'wfniter': 200, 'orbiter': 100},
-    'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
-    'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
-    'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
-    'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
-    'orbitaloptimizer': 'variational'
-}
-)
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energy, c, l = ap1rog(one, er, external['nn'], orb, olp, True, **{
+        'indextrans': 'tensordot',
+        'warning': False,
+        'checkpoint': 1,
+        'levelshift': 1e-8,
+        'absolute': False,
+        'givensrot': np.array([[]]),
+        'swapa': np.array([[]]),
+        'sort': True,
+        'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
+        'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
+        'maxiter': {'wfniter': 200, 'orbiter': 100},
+        'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
+        'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
+        'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
+        'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
+        'orbitaloptimizer': 'variational'
+    })

--- a/data/examples/ap1rog/water_dense_cc-pvdz.py
+++ b/data/examples/ap1rog/water_dense_cc-pvdz.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
-from horton import *
 import numpy as np
+
+from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -49,22 +51,22 @@ one.iadd(na)
 ## Do OO-AP1roG optimization ##################################################
 ###############################################################################
 ap1rog = RAp1rog(lf, occ_model)
-energy, c, l = ap1rog(one, er, external['nn'], orb, olp, True, **{
-    'indextrans': 'tensordot',
-    'warning': False,
-    'checkpoint': 1,
-    'levelshift': 1e-8,
-    'absolute': False,
-    'givensrot': np.array([[]]),
-    'swapa': np.array([[]]),
-    'sort': True,
-    'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
-    'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
-    'maxiter': {'wfniter': 200, 'orbiter': 100},
-    'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
-    'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
-    'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
-    'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
-    'orbitaloptimizer': 'variational'
-}
-)
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energy, c, l = ap1rog(one, er, external['nn'], orb, olp, True, **{
+        'indextrans': 'tensordot',
+        'warning': False,
+        'checkpoint': 1,
+        'levelshift': 1e-8,
+        'absolute': False,
+        'givensrot': np.array([[]]),
+        'swapa': np.array([[]]),
+        'sort': True,
+        'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
+        'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
+        'maxiter': {'wfniter': 200, 'orbiter': 100},
+        'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
+        'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
+        'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
+        'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
+        'orbitaloptimizer': 'variational'
+    })

--- a/data/examples/ap1rog/water_dense_sto-3g.py
+++ b/data/examples/ap1rog/water_dense_sto-3g.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
-from horton import *
 import numpy as np
+
+from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -49,22 +51,22 @@ one.iadd(na)
 ## Do OO-AP1roG optimization ##################################################
 ###############################################################################
 ap1rog = RAp1rog(lf, occ_model)
-energy, c, l = ap1rog(one, er, external['nn'], orb, olp, True, **{
-    'indextrans': 'tensordot',
-    'warning': False,
-    'checkpoint': 1,
-    'levelshift': 1e-8,
-    'absolute': False,
-    'givensrot': np.array([[]]),
-    'swapa': np.array([[]]),
-    'sort': True,
-    'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
-    'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
-    'maxiter': {'wfniter': 200, 'orbiter': 100},
-    'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
-    'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
-    'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
-    'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
-    'orbitaloptimizer': 'variational'
-}
-)
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energy, c, l = ap1rog(one, er, external['nn'], orb, olp, True, **{
+        'indextrans': 'tensordot',
+        'warning': False,
+        'checkpoint': 1,
+        'levelshift': 1e-8,
+        'absolute': False,
+        'givensrot': np.array([[]]),
+        'swapa': np.array([[]]),
+        'sort': True,
+        'guess': {'type': 'random', 'factor': -0.1, 'geminal': None, 'lagrange': None},
+        'solver': {'wfn': 'krylov', 'lagrange': 'krylov'},
+        'maxiter': {'wfniter': 200, 'orbiter': 100},
+        'dumpci': {'amplitudestofile': False, 'amplitudesfilename': './ap1rog_amplitudes.dat'},
+        'thresh': {'wfn':  1e-12, 'energy': 1e-8, 'gradientnorm': 1e-4, 'gradientmax': 5e-5},
+        'printoptions': {'geminal': True, 'ci': 0.01, 'excitationlevel': 1},
+        'stepsearch': {'method': 'trust-region', 'alpha': 1.0, 'c1': 0.0001, 'minalpha': 1e-6, 'maxiterouter': 10, 'maxiterinner': 500, 'maxeta': 0.75, 'mineta': 0.25, 'upscale': 2.0, 'downscale': 0.25, 'trustradius': 0.75, 'maxtrustradius': 0.75, 'threshold': 1e-8, 'optimizer': 'ddl'},
+        'orbitaloptimizer': 'variational'
+    })

--- a/data/examples/ap1rog/water_minimal.py
+++ b/data/examples/ap1rog/water_minimal.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 from horton import *
+from horton.test.common import numpy_seed
+
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
 ###############################################################################
@@ -48,4 +50,5 @@ one.iadd(na)
 ## Do OO-AP1roG optimization ##################################################
 ###############################################################################
 ap1rog = RAp1rog(lf, occ_model)
-energy, c, l = ap1rog(one, two, external['nn'], orb, olp, True)
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energy, c, l = ap1rog(one, two, external['nn'], orb, olp, True)

--- a/data/examples/perturbation_theory/mp2_h2_4-31g.py
+++ b/data/examples/perturbation_theory/mp2_h2_4-31g.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -53,4 +54,5 @@ one.iadd(na)
 ## Do RMP2 calculation ########################################################
 ###############################################################################
 mp2 = RMP2(lf, occ_model)
-emp2, tmp2 = mp2(one, er, orb, **{'eref': ehf})
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    emp2, tmp2 = mp2(one, er, orb, **{'eref': ehf})

--- a/data/examples/perturbation_theory/mp2_h2_cc-pvdz.py
+++ b/data/examples/perturbation_theory/mp2_h2_cc-pvdz.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -53,4 +54,5 @@ one.iadd(na)
 ## Do RMP2 calculation ########################################################
 ###############################################################################
 mp2 = RMP2(lf, occ_model)
-emp2, tmp2 = mp2(one, er, orb, **{'eref': ehf})
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    emp2, tmp2 = mp2(one, er, orb, **{'eref': ehf})

--- a/data/examples/perturbation_theory/mp2_h2_def2-svpd.py
+++ b/data/examples/perturbation_theory/mp2_h2_def2-svpd.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -53,4 +54,5 @@ one.iadd(na)
 ## Do RMP2 calculation ########################################################
 ###############################################################################
 mp2 = RMP2(lf, occ_model)
-emp2, tmp2 = mp2(one, er, orb, **{'eref': ehf})
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    emp2, tmp2 = mp2(one, er, orb, **{'eref': ehf})

--- a/data/examples/perturbation_theory/mp2_water_4-31g.py
+++ b/data/examples/perturbation_theory/mp2_water_4-31g.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -53,4 +54,5 @@ one.iadd(na)
 ## Do RMP2 calculation ########################################################
 ###############################################################################
 mp2 = RMP2(lf, occ_model)
-emp2, tmp2 = mp2(one, er, orb, **{'eref': ehf})
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    emp2, tmp2 = mp2(one, er, orb, **{'eref': ehf})

--- a/data/examples/perturbation_theory/mp2_water_cc-pvdz.py
+++ b/data/examples/perturbation_theory/mp2_water_cc-pvdz.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -53,4 +54,5 @@ one.iadd(na)
 ## Do RMP2 calculation ########################################################
 ###############################################################################
 mp2 = RMP2(lf, occ_model)
-emp2, tmp2 = mp2(one, er, orb, **{'eref': ehf})
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    emp2, tmp2 = mp2(one, er, orb, **{'eref': ehf})

--- a/data/examples/perturbation_theory/mp2_water_def2-svpd.py
+++ b/data/examples/perturbation_theory/mp2_water_def2-svpd.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -53,4 +54,5 @@ one.iadd(na)
 ## Do RMP2 calculation ########################################################
 ###############################################################################
 mp2 = RMP2(lf, occ_model)
-emp2, tmp2 = mp2(one, er, orb, **{'eref': ehf})
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    emp2, tmp2 = mp2(one, er, orb, **{'eref': ehf})

--- a/data/examples/perturbation_theory/pta_h2_4-31g.py
+++ b/data/examples/perturbation_theory/pta_h2_4-31g.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -55,4 +56,5 @@ energy, g, l = ap1rog(one, er, external['nn'], orb, olp, True)
 ## Do PTa calculation #########################################################
 ###############################################################################
 pta = PTa(lf, occ_model)
-energypta, amplitudes = pta(one, er, orb, g, **{'eref': energy, 'ecore': external['nn']})
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energypta, amplitudes = pta(one, er, orb, g, **{'eref': energy, 'ecore': external['nn']})

--- a/data/examples/perturbation_theory/pta_h2_cc-pvdz.py
+++ b/data/examples/perturbation_theory/pta_h2_cc-pvdz.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -55,4 +56,5 @@ energy, g, l = ap1rog(one, er, external['nn'], orb, olp, True)
 ## Do PTa calculation #########################################################
 ###############################################################################
 pta = PTa(lf, occ_model)
-energypta, amplitudes = pta(one, er, orb, g, **{'eref': energy, 'ecore': external['nn']})
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energypta, amplitudes = pta(one, er, orb, g, **{'eref': energy, 'ecore': external['nn']})

--- a/data/examples/perturbation_theory/pta_h2_def2-svpd.py
+++ b/data/examples/perturbation_theory/pta_h2_def2-svpd.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -55,4 +56,5 @@ energy, g, l = ap1rog(one, er, external['nn'], orb, olp, True)
 ## Do PTa calculation #########################################################
 ###############################################################################
 pta = PTa(lf, occ_model)
-energypta, amplitudes = pta(one, er, orb, g, **{'eref': energy, 'ecore': external['nn']})
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energypta, amplitudes = pta(one, er, orb, g, **{'eref': energy, 'ecore': external['nn']})

--- a/data/examples/perturbation_theory/pta_water_4-31g.py
+++ b/data/examples/perturbation_theory/pta_water_4-31g.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -55,4 +56,5 @@ energy, g, l = ap1rog(one, er, external['nn'], orb, olp, True)
 ## Do PTa calculation #########################################################
 ###############################################################################
 pta = PTa(lf, occ_model)
-energypta, amplitudes = pta(one, er, orb, g, **{'eref': energy, 'ecore': external['nn']})
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energypta, amplitudes = pta(one, er, orb, g, **{'eref': energy, 'ecore': external['nn']})

--- a/data/examples/perturbation_theory/pta_water_cc-pvdz.py
+++ b/data/examples/perturbation_theory/pta_water_cc-pvdz.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -55,4 +56,5 @@ energy, g, l = ap1rog(one, er, external['nn'], orb, olp, True)
 ## Do PTa calculation #########################################################
 ###############################################################################
 pta = PTa(lf, occ_model)
-energypta, amplitudes = pta(one, er, orb, g, **{'eref': energy, 'ecore': external['nn']})
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energypta, amplitudes = pta(one, er, orb, g, **{'eref': energy, 'ecore': external['nn']})

--- a/data/examples/perturbation_theory/pta_water_def2-svpd.py
+++ b/data/examples/perturbation_theory/pta_water_def2-svpd.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -55,4 +56,5 @@ energy, g, l = ap1rog(one, er, external['nn'], orb, olp, True)
 ## Do PTa calculation #########################################################
 ###############################################################################
 pta = PTa(lf, occ_model)
-energypta, amplitudes = pta(one, er, orb, g, **{'eref': energy, 'ecore': external['nn']})
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energypta, amplitudes = pta(one, er, orb, g, **{'eref': energy, 'ecore': external['nn']})

--- a/data/examples/perturbation_theory/ptb_h2_4-31g.py
+++ b/data/examples/perturbation_theory/ptb_h2_4-31g.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -55,4 +56,5 @@ energy, g, l = ap1rog(one, er, external['nn'], orb, olp, True)
 ## Do PTb calculation #########################################################
 ###############################################################################
 ptb = PTb(lf, occ_model)
-energyptb, amplitudes = ptb(one, er, orb, g, **{'eref': energy, 'ecore': external['nn'], 'threshold': 1e-6})
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energyptb, amplitudes = ptb(one, er, orb, g, **{'eref': energy, 'ecore': external['nn'], 'threshold': 1e-6})

--- a/data/examples/perturbation_theory/ptb_h2_cc-pvdz.py
+++ b/data/examples/perturbation_theory/ptb_h2_cc-pvdz.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -55,4 +56,5 @@ energy, g, l = ap1rog(one, er, external['nn'], orb, olp, True)
 ## Do PTb calculation #########################################################
 ###############################################################################
 ptb = PTb(lf, occ_model)
-energyptb, amplitudes = ptb(one, er, orb, g, **{'eref': energy, 'ecore': external['nn'], 'threshold': 1e-6})
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energyptb, amplitudes = ptb(one, er, orb, g, **{'eref': energy, 'ecore': external['nn'], 'threshold': 1e-6})

--- a/data/examples/perturbation_theory/ptb_h2_def2-svpd.py
+++ b/data/examples/perturbation_theory/ptb_h2_def2-svpd.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -55,4 +56,5 @@ energy, g, l = ap1rog(one, er, external['nn'], orb, olp, True)
 ## Do PTb calculation #########################################################
 ###############################################################################
 ptb = PTb(lf, occ_model)
-energyptb, amplitudes = ptb(one, er, orb, g, **{'eref': energy, 'ecore': external['nn'], 'threshold': 1e-6})
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energyptb, amplitudes = ptb(one, er, orb, g, **{'eref': energy, 'ecore': external['nn'], 'threshold': 1e-6})

--- a/data/examples/perturbation_theory/ptb_water_4-31g.py
+++ b/data/examples/perturbation_theory/ptb_water_4-31g.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -55,4 +56,5 @@ energy, g, l = ap1rog(one, er, external['nn'], orb, olp, True)
 ## Do PTb calculation #########################################################
 ###############################################################################
 ptb = PTb(lf, occ_model)
-energyptb, amplitudes = ptb(one, er, orb, g, **{'eref': energy, 'ecore': external['nn'], 'threshold': 1e-6})
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energyptb, amplitudes = ptb(one, er, orb, g, **{'eref': energy, 'ecore': external['nn'], 'threshold': 1e-6})

--- a/data/examples/perturbation_theory/ptb_water_cc-pvdz.py
+++ b/data/examples/perturbation_theory/ptb_water_cc-pvdz.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -55,4 +56,5 @@ energy, g, l = ap1rog(one, er, external['nn'], orb, olp, True)
 ## Do PTb calculation #########################################################
 ###############################################################################
 ptb = PTb(lf, occ_model)
-energyptb, amplitudes = ptb(one, er, orb, g, **{'eref': energy, 'ecore': external['nn'], 'threshold': 1e-6})
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energyptb, amplitudes = ptb(one, er, orb, g, **{'eref': energy, 'ecore': external['nn'], 'threshold': 1e-6})

--- a/data/examples/perturbation_theory/ptb_water_def2-svpd.py
+++ b/data/examples/perturbation_theory/ptb_water_def2-svpd.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from horton import *
+from horton.test.common import numpy_seed
 
 ###############################################################################
 ## Set up molecule, define basis set ##########################################
@@ -55,4 +56,5 @@ energy, g, l = ap1rog(one, er, external['nn'], orb, olp, True)
 ## Do PTb calculation #########################################################
 ###############################################################################
 ptb = PTb(lf, occ_model)
-energyptb, amplitudes = ptb(one, er, orb, g, **{'eref': energy, 'ecore': external['nn'], 'threshold': 1e-6})
+with numpy_seed():  # reproducible 'random' numbers to make sure it always works
+    energyptb, amplitudes = ptb(one, er, orb, g, **{'eref': energy, 'ecore': external['nn'], 'threshold': 1e-6})

--- a/doc/tech_dev_checklist.rst
+++ b/doc/tech_dev_checklist.rst
@@ -164,7 +164,7 @@ sure the fast unit tests follow these rules:
 
 * **MM205** When tests use random numbers, use a fixed random seed, such that at every
   execution the same random numbers are used. This avoids that a test breaks every now and
-  then.
+  then. See :ref:`tech_dev_unit_tests_random`.
 
 * **MM206** Avoid tests that just compare the output of a routine with the output from a
   previous initial version of that routine. Such tests need to be redone each time a bug

--- a/doc/tech_dev_unit_tests.rst
+++ b/doc/tech_dev_unit_tests.rst
@@ -60,7 +60,9 @@ with ``test_``. In these modules, all functions with a name that starts with
 ``test_`` are picked up by Nosetests. Tests that do not follow this convention
 are simply ignored.
 
-The basic structure of a test is as follows::
+The basic structure of a test is as follows:
+
+.. code-block:: python
 
     def test_sum():
         a = 1
@@ -74,8 +76,9 @@ test (similar to what you have in mind) and start modifying it.
 Most test packages in ``horton`` contain a ``common`` module that contains useful
 functions that facilitate the development of tests. An important example is the
 ``check_delta`` function to test if analytical derivatives are properly
-implemented. This is a simple example::
+implemented. This is a simple example:
 
+.. code-block:: python
 
     import numpy as np
     from horton.common import check_delta
@@ -105,7 +108,9 @@ Writing tests that need a temporary directory
 ---------------------------------------------
 
 A context manager is implemented in ``horton.test.common`` to simplify tests
-that need a temporary working directory. It can be used as follows::
+that need a temporary working directory. It can be used as follows:
+
+.. code-block:: python
 
     from horton.test.common import tmpdir
 
@@ -117,3 +122,30 @@ that need a temporary working directory. It can be used as follows::
 On most systems, this temporary directory is a subdirectory of ``/tmp``. The
 argument ``'horton.somemodule.test.test_something'`` will occur in the directory
 name, such that it can be easily recognized if needed.
+
+
+.. _tech_dev_unit_tests_random:
+
+Writing tests that use random numbers
+-------------------------------------
+
+Tests that make use of random numbers can be problematic when they only fail sometimes for
+very specific and rare values of the random numbers. To avoid issues with such corner
+cases, one must fix the random seed in the tests as follows:
+
+.. code-block:: python
+
+    from horton.test.common import numpy_seed
+
+    def test_foo():
+        # Some deterministic test code here.
+        # ...
+        # The part of test that uses random numbers should be repeated several times
+        # with different random numbers to make use of the randomness.
+        for irep in xrange(100):
+            # Fix the seed differently but determinstically at each repetition.
+            with numpy_seed(irep):
+                # Test code that uses numpy.random should go here.
+
+The test ``test_tridiagsym_solve`` in ``horton/grid/test/test_cubic_spline.py`` is a
+realistic example that properly uses random numbers.

--- a/horton/correlatedwfn/test/test_1dm_ap1rog.py
+++ b/horton/correlatedwfn/test/test_1dm_ap1rog.py
@@ -24,7 +24,7 @@ import numpy as np
 from nose.plugins.attrib import attr
 
 from horton import *
-from horton.test.common import check_delta
+from horton.test.common import check_delta, numpy_seed
 
 
 @attr('slow')
@@ -58,7 +58,9 @@ def test_ap1rog_one_dm():
 
     # Do AP1roG optimization:
     geminal_solver = RAp1rog(lf, occ_model)
-    energy, g, l = geminal_solver(one, er, external['nn'], exp_alpha, olp, True, **{'checkpoint': -1, 'maxiter': {'orbiter': 0}})
+    with numpy_seed():
+        energy, g, l = geminal_solver(one, er, external['nn'], exp_alpha, olp, True,
+                                      checkpoint=-1, maxiter={'orbiter': 0})
 
     one_mo_ = lf.create_two_index()
     one_mo_.assign_two_index_transform(one, exp_alpha)
@@ -112,5 +114,6 @@ def test_ap1rog_one_dm():
         return a.ravel()
 
     x = one_mo_._array.ravel()
-    dxs = np.random.rand(100, 28*28)*0.00001
-    check_delta(fun, fun_deriv, x, dxs)
+    with numpy_seed():
+        dxs = np.random.rand(100, 28*28)*0.00001
+        check_delta(fun, fun_deriv, x, dxs)

--- a/horton/grid/test/test_cubic_spline.py
+++ b/horton/grid/test/test_cubic_spline.py
@@ -20,17 +20,21 @@
 #--
 
 
-import numpy as np, h5py as h5
+import numpy as np
+import h5py as h5
+
 from horton import *
+from horton.test.common import numpy_seed
 
 
 def test_tridiagsym_solve():
     N = 10
     A = np.zeros((N,N), float)
-    # randomize the diagonal
-    A.ravel()[::N+1] = np.random.uniform(1,2,N)
-    # randomize the upper diagonal
-    A.ravel()[1::N+1] = np.random.uniform(-1,0,N-1)
+    with numpy_seed():  # Make random numbers reproducible
+        # randomize the diagonal
+        A.ravel()[::N+1] = np.random.uniform(1,2,N)
+        # randomize the upper diagonal
+        A.ravel()[1::N+1] = np.random.uniform(-1,0,N-1)
     # clone the lower diagonal
     A.ravel()[N::N+1] = A.ravel()[1::N+1]
     # test the inverse for all possible basis vectors

--- a/horton/grid/test/test_cubic_spline.py
+++ b/horton/grid/test/test_cubic_spline.py
@@ -30,26 +30,27 @@ from horton.test.common import numpy_seed
 def test_tridiagsym_solve():
     N = 10
     A = np.zeros((N,N), float)
-    with numpy_seed():  # Make random numbers reproducible
-        # randomize the diagonal
-        A.ravel()[::N+1] = np.random.uniform(1,2,N)
-        # randomize the upper diagonal
-        A.ravel()[1::N+1] = np.random.uniform(-1,0,N-1)
-    # clone the lower diagonal
-    A.ravel()[N::N+1] = A.ravel()[1::N+1]
-    # test the inverse for all possible basis vectors
-    Ainv = np.linalg.inv(A)
-    for i in xrange(N):
-        right = np.zeros(N, float)
-        right[i] = 1.0
-        solution = np.zeros(N, float)
-        tridiagsym_solve(
-            A.ravel()[::N+1].copy(),
-            A.ravel()[N::N+1].copy(),
-            right, solution
-        )
-        error = abs(solution - Ainv[:,i]).max()
-        assert(error < 1e-12)
+    for irep in xrange(100):
+        with numpy_seed(irep):  # Make random numbers reproducible
+            # randomize the diagonal
+            A.ravel()[::N+1] = np.random.uniform(1,2,N)
+            # randomize the upper diagonal
+            A.ravel()[1::N+1] = np.random.uniform(-1,0,N-1)
+        # clone the lower diagonal
+        A.ravel()[N::N+1] = A.ravel()[1::N+1]
+        # test the inverse for all possible basis vectors
+        Ainv = np.linalg.inv(A)
+        for i in xrange(N):
+            right = np.zeros(N, float)
+            right[i] = 1.0
+            solution = np.zeros(N, float)
+            tridiagsym_solve(
+                A.ravel()[::N+1].copy(),
+                A.ravel()[N::N+1].copy(),
+                right, solution
+            )
+            error = abs(solution - Ainv[:,i]).max()
+            assert(error < 1e-9)
 
 
 def test_basics_identity():

--- a/horton/test/common.py
+++ b/horton/test/common.py
@@ -34,7 +34,7 @@ __all__ = [
     'compare_expansions', 'compare_all_expansions', 'compare_dms',
     'compare_all_dms', 'compare_operators', 'compare_occ_model', 'compare_exps',
     'compare_mols', 'compare_symmetries',
-    'tmpdir',
+    'tmpdir', 'numpy_seed',
 ]
 
 
@@ -357,3 +357,18 @@ def tmpdir(name):
         yield dn
     finally:
         shutil.rmtree(dn)
+
+
+@contextmanager
+def numpy_seed(seed=1):
+    """Temporarily set NumPy's random seed to a given number
+
+    Parameters
+    ----------
+    seed : int
+           The seed for NumPy's random number generator.
+    """
+    state = np.random.get_state()
+    np.random.seed(seed)
+    yield None
+    np.random.set_state(state)

--- a/horton/test/common.py
+++ b/horton/test/common.py
@@ -361,7 +361,7 @@ def tmpdir(name):
 
 @contextmanager
 def numpy_seed(seed=1):
-    """Temporarily set NumPy's random seed to a given number
+    """Temporarily set NumPy's random seed to a given number.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR fixes issue #12. There may be more tests that should use the `numpy_seed` context manager but most should be covered. Many randomized tests do not have (nor need) this fix. Applying this fix to all of them is probably overkill.

Please, also review the extra documentation.