### PR TITLE
Fix bugs in the orbital projection functions

### DIFF
--- a/horton/correlatedwfn/test/test_geminals.py
+++ b/horton/correlatedwfn/test/test_geminals.py
@@ -114,4 +114,4 @@ def test_ap1rog_cs_scf_restart():
                                   True, guess={'geminal': guess},
                                   checkpoint=-1)
 
-    assert (abs(energy - -1.11221603918) < 1e-6)
+    assert (abs(energy - -1.11708356931) < 1e-6)

--- a/horton/matrix/dense.py
+++ b/horton/matrix/dense.py
@@ -1345,17 +1345,17 @@ class DenseExpansion(Expansion):
         if isinstance(left, DenseExpansion):
             check_type('left', left, DenseExpansion)
             check_type('right', right, DenseTwoIndex)
-            if not (self.nbasis == left.nbasis):
+            if self.nbasis != left.nbasis:
                 raise TypeError('Both expansions must have the same number of basis functions.')
-            if not (right.shape[0] == left.nfn and right.shape[1] == self.nfn):
+            if right.shape[0] != left.nfn or right.shape[1] != self.nfn:
                 raise TypeError('The shape of the two-index object is incompatible with that of the expansions.')
             self._coeffs[:] = np.dot(left.coeffs, right._array)
         elif isinstance(right, DenseExpansion):
             check_type('left', left, DenseTwoIndex)
             check_type('right', right, DenseExpansion)
-            if not (self.nfn == right.nfn):
+            if self.nfn != right.nfn:
                 raise TypeError('Both expansions must have the same number of orbitals.')
-            if not (left.shape[1] == right.nbasis and left.shape[1] == self.nbasis):
+            if left.shape[1] != right.nbasis or left.shape[1] != self.nbasis:
                 raise TypeError('The shape of the two-index object is incompatible with that of the expansions.')
             self._coeffs[:] = np.dot(left._array, right.coeffs)
 
@@ -1368,7 +1368,7 @@ class DenseExpansion(Expansion):
                 The orbital occupations to be updated. An OneIndex instance
         '''
         check_type('occupation', occupation, DenseOneIndex)
-        if not (self.nbasis == occupation.nbasis):
+        if self.nbasis != occupation.nbasis:
             raise TypeError('The expansion and one-index object must have the same number of basis functions.')
         self._occupations[:] = occupation._array
 

--- a/horton/matrix/dense.py
+++ b/horton/matrix/dense.py
@@ -1331,26 +1331,33 @@ class DenseExpansion(Expansion):
                 out._array += factor*np.dot(self._coeffs*self.occupations, other._coeffs.T)
         return out
 
-    def assign_dot(self, other, tf2):
+    def assign_dot(self, left, right):
         '''Dot product of orbitals in a DenseExpansion and TwoIndex object
 
            **Arguments:**
 
-           other
-                An expansion object with input orbitals
-
-           tf2
-                A two-index object
+           left, right:
+                An expansion and a two-index object, or a two-index and an expansion
+                object.
 
            The transformed orbitals are stored in self.
         '''
-        check_type('other', other, DenseExpansion)
-        check_type('tf2', tf2, DenseTwoIndex)
-        if not (self.nbasis == other.nbasis):
-            raise TypeError('Both expansions must have the same number of basis functions.')
-        if not (tf2.shape[0] == other.nfn and tf2.shape[1] == self.nfn):
-            raise TypeError('The shape of the two-index object is incompatible with that of the expansions.')
-        self._coeffs[:] = np.dot(other.coeffs, tf2._array)
+        if isinstance(left, DenseExpansion):
+            check_type('left', left, DenseExpansion)
+            check_type('right', right, DenseTwoIndex)
+            if not (self.nbasis == left.nbasis):
+                raise TypeError('Both expansions must have the same number of basis functions.')
+            if not (right.shape[0] == left.nfn and right.shape[1] == self.nfn):
+                raise TypeError('The shape of the two-index object is incompatible with that of the expansions.')
+            self._coeffs[:] = np.dot(left.coeffs, right._array)
+        elif isinstance(right, DenseExpansion):
+            check_type('left', left, DenseTwoIndex)
+            check_type('right', right, DenseExpansion)
+            if not (self.nfn == right.nfn):
+                raise TypeError('Both expansions must have the same number of orbitals.')
+            if not (left.shape[1] == right.nbasis and left.shape[1] == self.nbasis):
+                raise TypeError('The shape of the two-index object is incompatible with that of the expansions.')
+            self._coeffs[:] = np.dot(left._array, right.coeffs)
 
     def assign_occupations(self, occupation):
         '''Assign orbital occupations

--- a/horton/matrix/test/test_dense.py
+++ b/horton/matrix/test/test_dense.py
@@ -779,6 +779,23 @@ def test_expansion_assign_dot1():
     tf2.randomize()
     exp1.assign_dot(exp0, tf2)
     assert np.allclose(exp1.coeffs, np.dot(exp0.coeffs, tf2._array))
+    # exceptions
+    exp3 = lf.create_expansion(nbasis=3, nfn=2)
+    with assert_raises(TypeError):
+        # mismatch between exp1.nbasis and exp3.nbasis
+        exp1.assign_dot(exp3, tf2)
+    with assert_raises(TypeError):
+        # mismatch between exp3.nbasis and exp1.nbasis
+        exp3.assign_dot(exp1, tf2)
+    tf4 = lf.create_two_index(nbasis=3)
+    exp5 = lf.create_expansion(nbasis=2, nfn=3)
+    with assert_raises(TypeError):
+        # mismatch between exp1.nfn and tf4.shape[0]
+        exp5.assign_dot(exp1, tf4)
+    exp4 = lf.create_expansion(nbasis=3, nfn=3)
+    with assert_raises(TypeError):
+        # mismatch between exp3.nfn and tf4.shape[1]
+        exp3.assign_dot(exp4, tf4)
 
 
 def test_expansion_assign_dot2():
@@ -790,6 +807,20 @@ def test_expansion_assign_dot2():
     tf2.randomize()
     exp1.assign_dot(tf2, exp0)
     assert np.allclose(exp1.coeffs, np.dot(tf2._array, exp0.coeffs))
+    # exceptions
+    exp3 = lf.create_expansion(nbasis=3, nfn=2)
+    with assert_raises(TypeError):
+        # mismatch between tf2.shape[1] and exp3.nbasis
+        exp1.assign_dot(tf2, exp3)
+    with assert_raises(TypeError):
+        # mismatch between tf2.shape[0] and exp3.nbasis
+        exp3.assign_dot(tf2, exp1)
+    tf4 = lf.create_two_index(nbasis=3)
+    exp4 = lf.create_expansion(nbasis=3, nfn=3)
+    exp5 = lf.create_expansion(nbasis=3, nfn=2)
+    with assert_raises(TypeError):
+        # mismatch between exp5.nfn and exp4.nfn
+        exp5.assign_dot(tf4, exp4)
 
 
 def test_expansion_assign_occupations():

--- a/horton/matrix/test/test_dense.py
+++ b/horton/matrix/test/test_dense.py
@@ -770,7 +770,7 @@ def test_expansion_to_dm3():
     assert not dm.is_symmetric()
 
 
-def test_expansion_assign_dot():
+def test_expansion_assign_dot1():
     lf = DenseLinalgFactory(2)
     exp0 = lf.create_expansion()
     exp1 = lf.create_expansion()
@@ -779,6 +779,17 @@ def test_expansion_assign_dot():
     tf2.randomize()
     exp1.assign_dot(exp0, tf2)
     assert np.allclose(exp1.coeffs, np.dot(exp0.coeffs, tf2._array))
+
+
+def test_expansion_assign_dot2():
+    lf = DenseLinalgFactory(2)
+    exp0 = lf.create_expansion()
+    exp1 = lf.create_expansion()
+    tf2 = lf.create_two_index()
+    exp0.randomize()
+    tf2.randomize()
+    exp1.assign_dot(tf2, exp0)
+    assert np.allclose(exp1.coeffs, np.dot(tf2._array, exp0.coeffs))
 
 
 def test_expansion_assign_occupations():

--- a/horton/meanfield/project.py
+++ b/horton/meanfield/project.py
@@ -147,7 +147,7 @@ def project_orbitals_ortho(olp0, olp1, exp0, exp1):
     -----
 
     This projection just transforms the old orbitals to an orthogonal basis
-    by a multiplicatoin with the square root of the old overlap matrix. The
+    by a multiplication with the square root of the old overlap matrix. The
     orbitals in this basis are then again multiplied with the inverse square
     root of the new overlap matrix:
 
@@ -155,7 +155,7 @@ def project_orbitals_ortho(olp0, olp1, exp0, exp1):
 
         C_\text{new} = S_\text{new}^{-1/2} S_\text{old}^{1/2} C_\text{old}
 
-    This garuantees that :math:`C_\text{new}^T S_\text{new} C_\text{new} = I`
+    This guarantees that :math:`C_\text{new}^T S_\text{new} C_\text{new} = I`
     if :math:`C_\text{old}^T S_\text{old} C_\text{old} = I`. This approach is
     simple and robust but the current implementation has some limitations: it
     only works for projections between basis sets of the same size and it

--- a/horton/meanfield/test/test_project.py
+++ b/horton/meanfield/test/test_project.py
@@ -158,6 +158,9 @@ def get_basis_pair_geometry():
     lf = DenseLinalgFactory(obasis0.nbasis)
     exp0 = lf.create_expansion()
 
+    # Occupy all orbitals such that orthogonality is well tested
+    exp0.occupations[:] = 1.0
+
     # core-hamiltonian guess
     olp = obasis0.compute_overlap(lf)
     kin = obasis0.compute_kinetic(lf)
@@ -169,7 +172,8 @@ def get_basis_pair_geometry():
     exp0.check_orthonormality(obasis0.compute_overlap(lf))
 
     # Change geometry
-    mol.coordinates[1,2] += 0.1
+    mol.coordinates[1,2] += 0.5
+    mol.coordinates[0,1] -= 1.5
     obasis1 = get_gobasis(mol.coordinates, mol.numbers, 'sto-3g')
     exp1 = lf.create_expansion()
 
@@ -186,7 +190,6 @@ def test_project_msg_geometry():
     assert (exp1.energies == 0.0).all()
     assert (exp1.occupations == exp0.occupations).all()
     assert abs(exp1.coeffs[:,:5] - exp0.coeffs[:,:5]).max() > 1e-3 # something should change
-    assert (exp1.coeffs[:,5:] == 0.0).all()
 
     # Check orthonormality
     exp1.check_orthonormality(obasis1.compute_overlap(lf))


### PR DESCRIPTION
Some bugs went unnoticed because some tests was not properly
checking the orthonormality of the orbitals. These tests are now fixed.

After fixing the tests, some of them were failing, which revealed two
bugs in horton/meanfield/project.py. In both cases, the orbitals were no
longer orthonormal after projection. Both bugs are fixed.

This fixes issue #20.