### PR TITLE
Build recent version of CPPCheck on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ addons:
      # libtool is needed by libint
      - libtool
      - doxygen
-     - cppcheck
+     # libpcre3-dev is needed to build a recent cppcheck
+     - libpcre3-dev
 
 env:
   global:

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -334,7 +334,10 @@
 }, {
     "name": "cppcheck",
     "title": "Cppcheck",
-    "version_requirement": ">= 1.52",
+    "version_requirement": ">= 1.73",
+    "version_ci": "1.73",
+    "install_command": "./tools/qa/install_cppcheck-1.73.sh",
+    "source_url": "http://downloads.sourceforge.net/project/cppcheck/cppcheck/1.73/cppcheck-1.73.tar.bz2",
     "homepage": "http://cppcheck.sourceforge.net/",
     "fedora_24_rpm": "cppcheck",
     "fedora_22_rpm": "cppcheck",

--- a/doc/tech_dev_checklist.rst
+++ b/doc/tech_dev_checklist.rst
@@ -518,12 +518,14 @@ W1605, W1606, W1607, W1608, W1609, W1610, W1611, W1612, W1613, W1614, W1615, W16
 W1618, W1619, W1620, W1621, W1622, W1623, W1624, W1625, W1626, W1627, W1628, W1629, W1630,
 W1632, W1633, W1634, W1635, W1636, W1637, W1638, W1639, W1640
 
-The following are excluded because we don't agree:
+The following are excluded because we don't consider them the be fatal:
 
 * **C0103**: invalid-name. Invalid %s name “%s”%s Used when the name doesn’t match
   the regular expression associated to its type (constant, variable, class...).
 * **I0011**: locally-disabled. Used when an inline option disables a message or a messages
   category.
+* **W0613**: unused-argument. Unused argument %r Used when a function or method argument
+  is not used.
 
 The following is disabled to allow access to the protected members of the
 (not-so-well-designed) Matrix classes:

--- a/tools/qa/install_cppcheck-1.73.sh
+++ b/tools/qa/install_cppcheck-1.73.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+VERSION=1.73
+NAMEVER=cppcheck-${VERSION}
+set -e
+source tools/qa/common.sh
+if [ ! -d "${CACHED}/${NAMEVER}/cppcheck" ]; then
+(
+    echo -e "${GREEN}Building and installing ${NAMEVER} from scratch${RESET}"
+    cd ${QAWORKDIR}
+    mkdir -p depbuild
+    cd depbuild
+    curl -OL "http://downloads.sourceforge.net/project/cppcheck/cppcheck/${VERSION}/${NAMEVER}.tar.bz2"
+    tar -xjf ${NAMEVER}.tar.bz2
+    cd ${NAMEVER}
+    echo "Actual build and install. This may take a while."
+    make SRCDIR=build CFGDIR=${CACHED}/${NAMEVER}/cfg HAVE_RULES=yes CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function" &> install.log
+    tail install.log
+    mkdir -p ${CACHED}/${NAMEVER}
+    cp -av cppcheck ${CACHED}/${NAMEVER}
+    cp -av cfg ${CACHED}/${NAMEVER}
+)
+else
+    echo -e "${GREEN}Using Cached ${NAMEVER}${RESET}"
+fi

--- a/tools/qa/pylintrc
+++ b/tools/qa/pylintrc
@@ -16,7 +16,7 @@ persistent=no
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=pylint.extensions.check_docs
+load-plugins=
 
 # Use multiple processes to speed up Pylint.
 jobs=1
@@ -59,7 +59,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=I0020,I0021,W0704,E0611,E1101,C0103,W0212,I0011,R0201,C0411
+disable=I0020,I0021,W0704,E0611,E1101,C0103,W0212,I0011,R0201,C0411,W0613
 #disable=all
 
 [REPORTS]

--- a/tools/qa/trapdoor_coverage.py
+++ b/tools/qa/trapdoor_coverage.py
@@ -27,11 +27,10 @@ This test calls the nosetests and coverage, see:
 """
 
 
-import subprocess
 from collections import Counter
 from xml.etree import ElementTree
 
-from trapdoor import TrapdoorProgram, Message
+from trapdoor import TrapdoorProgram, Message, run_command
 
 
 class CoverageTrapdoorProgram(TrapdoorProgram):
@@ -58,9 +57,9 @@ class CoverageTrapdoorProgram(TrapdoorProgram):
         """
         # Get version
         command = ['nosetests', '--version']
-        print 'USING', subprocess.check_output(command, stderr=subprocess.STDOUT).strip()
+        print 'USING              :', run_command(command, verbose=False)[0].strip()
         command = ['coverage', '--version']
-        print 'USING', subprocess.check_output(command, stderr=subprocess.STDOUT).split('\n')[0]
+        print 'USING              :', run_command(command, verbose=False)[0].split('\n')[0]
 
         # Results will be stored in the following variables
         counter = Counter()
@@ -71,9 +70,7 @@ class CoverageTrapdoorProgram(TrapdoorProgram):
                    '--cover-branches',
                    '--cover-package=%s' % ','.join(config['py_packages'])] + \
                    config['py_directories']
-        print 'RUNNING', ' '.join(command)
-        proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        output = proc.communicate()[0]
+        output = run_command(command)[0]
         lines = [line.strip() for line in output.split('\n')]
 
         # Parse the output of the unit tests
@@ -94,9 +91,7 @@ class CoverageTrapdoorProgram(TrapdoorProgram):
         fn_coverage = '%s/coverage.xml' % self.qaworkdir
         command = ['coverage', 'xml', '-o', fn_coverage,
                    '--omit=%s' % ','.join(config['py_test_files'])]
-        print 'RUNNING', ' '.join(command)
-        proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        output = proc.communicate()[0]
+        output = run_command(command)[0]
 
         # Parse coverage xml output
         et = ElementTree.parse(fn_coverage)

--- a/tools/qa/trapdoor_cppcheck.py
+++ b/tools/qa/trapdoor_cppcheck.py
@@ -25,9 +25,11 @@ This test calls the cppcheck program, see http://cppcheck.sourceforge.net/.
 """
 
 
+from collections import Counter
+from glob import glob
+import os
 import subprocess
 from xml.etree import ElementTree
-from collections import Counter
 
 from trapdoor import TrapdoorProgram, Message, get_source_filenames
 
@@ -54,12 +56,20 @@ class CPPCheckTrapdoorProgram(TrapdoorProgram):
         messages : Set([]) of strings
                    All errors encountered in the current branch.
         """
+        # Look for custom cppcheck build
+        fns_cppcheck = sorted(glob('%s/cached/cppcheck-*/cppcheck' % self.qaworkdir))
+        if len(fns_cppcheck) > 0:
+            binary = os.path.abspath(fns_cppcheck[-1])
+        else:
+            binary = 'cppcheck'
+        print 'USING BINARY', binary
+
         # Get version
-        command = ['cppcheck', '--version']
-        print 'USING', subprocess.check_output(command, stderr=subprocess.STDOUT).strip()
+        command = [binary, '--version']
+        print 'USING VERSION', subprocess.check_output(command, stderr=subprocess.STDOUT).strip()
 
         # Call Cppcheck
-        command = ['cppcheck'] + get_source_filenames(config, 'cpp') + \
+        command = [binary] + get_source_filenames(config, 'cpp') + \
                   ['-q', '--enable=all', '--std=c++11', '--xml',
                    '--suppress=missingIncludeSystem', '--suppress=unusedFunction']
         print 'RUNNING', ' '.join(command)

--- a/tools/qa/trapdoor_cppcheck.py
+++ b/tools/qa/trapdoor_cppcheck.py
@@ -28,10 +28,9 @@ This test calls the cppcheck program, see http://cppcheck.sourceforge.net/.
 from collections import Counter
 from glob import glob
 import os
-import subprocess
 from xml.etree import ElementTree
 
-from trapdoor import TrapdoorProgram, Message, get_source_filenames
+from trapdoor import TrapdoorProgram, Message, get_source_filenames, run_command
 
 
 class CPPCheckTrapdoorProgram(TrapdoorProgram):
@@ -62,18 +61,17 @@ class CPPCheckTrapdoorProgram(TrapdoorProgram):
             binary = os.path.abspath(fns_cppcheck[-1])
         else:
             binary = 'cppcheck'
-        print 'USING BINARY', binary
+        print 'USING BINARY       :', binary
 
         # Get version
         command = [binary, '--version']
-        print 'USING VERSION', subprocess.check_output(command, stderr=subprocess.STDOUT).strip()
+        print 'USING VERSION      :', run_command(command, verbose=False)[0].strip()
 
         # Call Cppcheck
         command = [binary] + get_source_filenames(config, 'cpp') + \
                   ['-q', '--enable=all', '--std=c++11', '--xml',
                    '--suppress=missingIncludeSystem', '--suppress=unusedFunction']
-        print 'RUNNING', ' '.join(command)
-        xml_str = subprocess.check_output(command, stderr=subprocess.STDOUT)
+        xml_str = run_command(command)[1]
         etree = ElementTree.fromstring(xml_str)
 
         # Parse the output of Cppcheck into standard return values

--- a/tools/qa/trapdoor_cpplint.py
+++ b/tools/qa/trapdoor_cpplint.py
@@ -29,10 +29,14 @@ https://github.com/google/styleguide/tree/gh-pages/cpplint.
 import os
 import shutil
 import stat
-import subprocess
 from collections import Counter
 
-from trapdoor import TrapdoorProgram, Message, get_source_filenames
+from trapdoor import TrapdoorProgram, Message, get_source_filenames, run_command
+
+
+def has_failed(returncode, stdout, stderr):
+    """Determine if cpplint.py has failed."""
+    return 'FATAL' in stdout
 
 
 class CPPLintTrapdoorProgram(TrapdoorProgram):
@@ -68,13 +72,11 @@ class CPPLintTrapdoorProgram(TrapdoorProgram):
                    All errors encountered in the current branch.
         """
         # Get version
-        print 'USING cpplint.py update #456'
+        print 'USING              : cpplint.py update #456'
 
         # Call cpplint
         command = [self.cpplint_file, '--linelength=100'] + get_source_filenames(config, 'cpp')
-        print 'RUNNING', ' '.join(command)
-        proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        output = proc.communicate()[0]
+        output = run_command(command, has_failed=has_failed)[0]
 
         # Parse the output of cpplint into standard return values
         counter = Counter()

--- a/tools/qa/trapdoor_doxygen.py
+++ b/tools/qa/trapdoor_doxygen.py
@@ -27,10 +27,9 @@ This test uses doxygen, see http://www.doxygen.org.
 
 import os
 import shutil
-import subprocess
 from collections import Counter
 
-from trapdoor import TrapdoorProgram, Message
+from trapdoor import TrapdoorProgram, Message, run_command
 
 
 def unwrapped_iter(f):
@@ -87,14 +86,11 @@ class DoxygenTrapdoorProgram(TrapdoorProgram):
         """
         # Get version
         command = ['doxygen', '--version']
-        print 'USING doxygen', subprocess.check_output(command).strip()
+        print 'USING              : doxygen', run_command(command, verbose=False)[0].strip()
 
         # Call doxygen in the doc subdirectory, mute output because it only confuses
         command = ['doxygen', self.doxyconf_file]
-        print 'RUNNING (in %s)' % config['doxygen_root'], ' '.join(command)
-        with open(os.devnull, 'wb') as devnull:
-            subprocess.check_call(command, cwd=config['doxygen_root'], stdout=devnull,
-                                  stderr=devnull)
+        run_command(command, cwd=config['doxygen_root'])
 
         # Parse the file doxygen_warnings log file
         counter = Counter()


### PR DESCRIPTION
- Fix for issue #72. This will build cppcheck on Travis/buildbot and cache the results. When present, this binary gets picked up automatically by trapdoor_cppcheck.py
- While testing the newer version of cppcheck, I found that the output of the trapdoor scripts should be made more helpful and consistent in case of faillure. That is also taken care of
- While improving the output of the trapdoor scripts, several useless pylint messages were generated. I've tuned pylintrc and documented the disabled checks. (The plugin checkdocs was disabled again, which is the pylint default. It was not mentioned in our docs yet.)