### PR TITLE
Fix normalization

### DIFF
--- a/horton/gbasis/gobasis.py
+++ b/horton/gbasis/gobasis.py
@@ -236,7 +236,7 @@ class GOBasisFamily(object):
         self._normalize_contractions()
 
     def _to_arrays(self):
-        '''Convert all contraction attributes to numpy arrays'''
+        """Convert all contraction attributes to numpy arrays."""
         for ba in self.basis_atom_map.itervalues():
             for bc in ba.bcs:
                 bc.to_arrays()
@@ -256,7 +256,7 @@ class GOBasisFamily(object):
         """Renormalize all contractions."""
         for ba in self.basis_atom_map.itervalues():
             for bc in ba.bcs:
-                bc.normalize_contraction()
+                bc.normalize()
 
 
 go_basis_families_list = [
@@ -377,27 +377,20 @@ class GOBasisContraction(object):
         return l
 
     def is_generalized(self):
-        '''Returns True if this is a generalized contraction
-
-           This routine also checks if the con_coeffs attribute is consistent.
-        '''
-        if len(self.con_coeffs.shape) == 2:
-            return True
-        elif len(self.con_coeffs.shape) == 1:
-            return False
-        else:
-            raise ValueError
+        """Returns True if this is a generalized contraction."""
+        return len(self.con_coeffs.shape) >= 2
 
     def get_segmented_bcs(self):
-        '''Returns a list of segmented contractions'''
+        """Returns a list of segmented contractions."""
         if not self.is_generalized():
-            raise TypeError('Conversion to segmented contractions only makes sense for generalized contractions.')
+            raise TypeError('Conversion to segmented contractions only makes sense for '
+                            'generalized contractions.')
         return [
-            GOBasisContraction(self.shell_type, self.alphas, self.con_coeffs[:,i])
+            GOBasisContraction(self.shell_type, self.alphas, self.con_coeffs[:, i])
             for i in xrange(self.con_coeffs.shape[1])
         ]
 
-    def normalize_contraction(self):
+    def normalize(self):
         """Normalize the contraction."""
         if self.is_generalized():
             raise NotImplementedError("Only segmented contractions can be normalized.")

--- a/horton/gbasis/gobasis.py
+++ b/horton/gbasis/gobasis.py
@@ -370,18 +370,12 @@ class GOBasisContraction(object):
         self.alphas = np.array(self.alphas)
         self.con_coeffs = np.array(self.con_coeffs)
 
-    def __length__(self):
-        '''Return the length of the contraction'''
-        l = len(self.alphas)
-        assert l == len(self.con_coeffs)
-        return l
-
     def is_generalized(self):
-        """Returns True if this is a generalized contraction."""
+        """Return True if this is a generalized contraction."""
         return len(self.con_coeffs.shape) >= 2
 
     def get_segmented_bcs(self):
-        """Returns a list of segmented contractions."""
+        """Return a list of segmented contractions."""
         if not self.is_generalized():
             raise TypeError('Conversion to segmented contractions only makes sense for '
                             'generalized contractions.')

--- a/horton/gbasis/test/test_gobasis.py
+++ b/horton/gbasis/test/test_gobasis.py
@@ -565,3 +565,33 @@ def test_basis_atoms():
         icenter += 1
         ibasis_all.extend(ibasis_list)
     assert ibasis_all == range(mol.obasis.nbasis)
+
+
+def check_normalization(number, basis):
+    """Helper function to test the normalization of contracted basis sets.
+
+    Parameters
+    ----------
+    number : int
+             Element to test. (Keep in mind that not all elements are supported in most
+             basis sets.)
+    basis : str
+            The basis set, e.g. cc-pvdz.
+    """
+    # Run test on a Helium atom
+    mol = IOData(coordinates=np.array([[0.0, 0.0, 0.0]]), numbers=np.array([number]))
+
+    # Create a Gaussian basis set
+    obasis = get_gobasis(mol.coordinates, mol.numbers, basis)
+
+    # Create a linalg factory
+    lf = DenseLinalgFactory(obasis.nbasis)
+
+    # Compute Gaussian integrals
+    olp = obasis.compute_overlap(lf)
+    np.testing.assert_almost_equal(np.diag(olp._array), 1.0)
+
+
+def test_normalization_ccpvdz():
+    for number in xrange(1, 18+1):
+        check_normalization(number, 'cc-pvdz')

--- a/horton/gbasis/test/test_iobas.py
+++ b/horton/gbasis/test/test_iobas.py
@@ -71,8 +71,8 @@ def test_go_basis_desc_hydrogen_321g():
     assert (obasis.shell_map == np.array([0,0])).all()
     assert (obasis.nprims == np.array([2,1])).all()
     assert (obasis.shell_types == np.array([0,0])).all()
-    assert abs(obasis.alphas - np.array([5.4471780, 0.8245470, 0.1831920])).all() < 1e-10
-    assert abs(obasis.con_coeffs - np.array([0.1562850, 0.9046910, 1.0000000])).all() < 1e-10
+    np.testing.assert_almost_equal(obasis.alphas, [5.4471780, 0.8245470, 0.1831920])
+    np.testing.assert_almost_equal(obasis.con_coeffs, [0.1562850, 0.9046910, 1.0000000])
     assert obasis.nbasis == 2
 
 
@@ -86,16 +86,17 @@ def test_go_basis_desc_lithium_321g():
     assert (obasis.shell_map == np.array([0,0,0,0,0])).all()
     assert (obasis.nprims == np.array([3,2,2,1,1])).all()
     assert (obasis.shell_types == np.array([0,0,1,0,1])).all()
-    assert abs(obasis.alphas - np.array([
+    np.testing.assert_almost_equal(obasis.alphas, [
         36.8382000, 5.4817200, 1.1132700,
         0.5402050, 0.1022550, 0.5402050, 0.1022550,
         0.0285650, 0.0285650,
-    ])).all() < 1e-10
-    assert abs(obasis.con_coeffs - np.array([
+    ])
+    # Limited precision due to normalization of contractions after loading them from file.
+    np.testing.assert_almost_equal(obasis.con_coeffs, [
         0.0696686, 0.3813460, 0.6817020,
-        -0.2631270, 0.1615460, 1.1433900, 0.9156630,
+        -0.2631270, 1.1433900, 0.1615460, 0.9156630,
         1.0000000, 1.0000000
-    ])).all() < 1e-10
+    ], decimal=4)
     assert obasis.nbasis == 9
 
 

--- a/horton/gbasis/test/test_iobas.py
+++ b/horton/gbasis/test/test_iobas.py
@@ -21,6 +21,7 @@
 
 
 import numpy as np
+from nose.tools import assert_raises
 
 from horton import *  # pylint: disable=wildcard-import,unused-wildcard-import
 
@@ -57,7 +58,7 @@ def test_fortran_float():
 
 
 def test_go_basis_desc_neon_sto3g():
-    obasis = get_gobasis(np.array([[0.0,0.0,0.0]]), np.array([2]), 'STO-3G')
+    obasis = get_gobasis(np.array([[0.0, 0.0, 0.0]]), np.array([2]), 'STO-3G')
     assert (obasis.shell_map == np.array([0])).all()
     assert (obasis.nprims == np.array([3])).all()
     assert (obasis.shell_types == np.array([0])).all()
@@ -102,9 +103,9 @@ def test_go_basis_desc_water_sto3g():
     fn = context.get_fn('test/water_element.xyz')
     mol = IOData.from_file(fn)
     obasis = get_gobasis(mol.coordinates, mol.numbers, 'STO-3G')
-    assert (obasis.shell_map == np.array([0,1,1,1,2])).all()
-    assert (obasis.nprims == np.array([3,3,3,3,3])).all()
-    assert (obasis.shell_types == np.array([0,0,0,1,0])).all()
+    assert (obasis.shell_map == np.array([0, 1, 1, 1, 2])).all()
+    assert (obasis.nprims == np.array([3, 3, 3, 3, 3])).all()
+    assert (obasis.shell_types == np.array([0, 0, 0, 1, 0])).all()
     expected_alphas = [
         3.42525091, 0.62391373, 0.16885540,
         130.7093200, 23.8088610, 6.4436083,
@@ -122,3 +123,18 @@ def test_go_basis_desc_water_sto3g():
     ]
     np.testing.assert_almost_equal(obasis.con_coeffs, expected_con_coeffs)
     assert obasis.nbasis == 7
+
+
+def test_gobasis_contraction_exceptions():
+    gbc = GOBasisContraction(1, [0.1, 1.0, 10.0], [[-0.3, 1.4], [4.4, 5.5], [2.2, -2.0]])
+    gbc.to_arrays()
+    assert gbc.is_generalized()
+    gbc1, gbc2 = gbc.get_segmented_bcs()
+    assert not gbc1.is_generalized()
+    assert not gbc2.is_generalized()
+    with assert_raises(TypeError):
+        gbc1.get_segmented_bcs()
+    with assert_raises(TypeError):
+        gbc2.get_segmented_bcs()
+    with assert_raises(NotImplementedError):
+        gbc.normalize()

--- a/horton/gbasis/test/test_iobas.py
+++ b/horton/gbasis/test/test_iobas.py
@@ -61,8 +61,8 @@ def test_go_basis_desc_neon_sto3g():
     assert (obasis.shell_map == np.array([0])).all()
     assert (obasis.nprims == np.array([3])).all()
     assert (obasis.shell_types == np.array([0])).all()
-    assert abs(obasis.alphas - np.array([6.36242139, 1.15892300, 0.31364979])).all() < 1e-10
-    assert abs(obasis.con_coeffs - np.array([0.15432897, 0.53532814, 0.44463454])).all() < 1e-10
+    np.testing.assert_almost_equal(obasis.alphas, [6.36242139, 1.15892300, 0.31364979])
+    np.testing.assert_almost_equal(obasis.con_coeffs, [0.15432897, 0.53532814, 0.44463454])
 
 
 def test_go_basis_desc_hydrogen_321g():
@@ -105,18 +105,20 @@ def test_go_basis_desc_water_sto3g():
     assert (obasis.shell_map == np.array([0,1,1,1,2])).all()
     assert (obasis.nprims == np.array([3,3,3,3,3])).all()
     assert (obasis.shell_types == np.array([0,0,0,1,0])).all()
-    assert abs(obasis.alphas - np.array([
+    expected_alphas = [
         3.42525091, 0.62391373, 0.16885540,
         130.7093200, 23.8088610, 6.4436083,
         5.0331513, 1.1695961, 0.3803890,
         5.0331513, 1.1695961, 0.3803890,
         3.42525091, 0.62391373, 0.16885540,
-    ])).all() < 1e-10
-    assert abs(obasis.con_coeffs - np.array([
+    ]
+    np.testing.assert_almost_equal(obasis.alphas, expected_alphas)
+    expected_con_coeffs = [
         0.15432897, 0.53532814, 0.44463454,
         0.15432897, 0.53532814, 0.44463454,
-        -0.09996723, 0.15591627, 0.39951283,
-        0.60768372, 0.70011547, 0.39195739,
+        -0.09996723, 0.39951283, 0.70011547,
+        0.15591627, 0.60768372, 0.39195739,
         0.15432897, 0.53532814, 0.44463454,
-    ])).all() < 1e-10
+    ]
+    np.testing.assert_almost_equal(obasis.con_coeffs, expected_con_coeffs)
     assert obasis.nbasis == 7

--- a/horton/gbasis/test/test_iobas.py
+++ b/horton/gbasis/test/test_iobas.py
@@ -125,7 +125,7 @@ def test_go_basis_desc_water_sto3g():
     assert obasis.nbasis == 7
 
 
-def test_gobasis_contraction_exceptions():
+def test_gobasis_contraction():
     gbc = GOBasisContraction(1, [0.1, 1.0, 10.0], [[-0.3, 1.4], [4.4, 5.5], [2.2, -2.0]])
     gbc.to_arrays()
     assert gbc.is_generalized()


### PR DESCRIPTION
This fixes #39. The `normalize` method is a little ugly because I'm locally constructing a basis set for the contraction to compute the normalization constant. The alternative (a nice implementation without using GOBasis) would imply a significant amount of extra code, which is also redundant w.r.t. the code in GOBasis.