### PR TITLE
Fix-ish docstring for C extension constructors

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -262,7 +262,7 @@ pngmath_dvipng_args = ['-gamma 1.6', '-D 120']
 
 sys.path.append('../')
 os.environ['HORTONDATA'] = '../data'
-autoclass_content = "class"
+autoclass_content = "init"
 autodoc_member_order = "groupwise"
 autodoc_default_flags = ['members', 'undoc-members', 'inherited-members', 'show-inheritance']
 

--- a/doc/tech_dev_documentation.rst
+++ b/doc/tech_dev_documentation.rst
@@ -125,3 +125,9 @@ The following problems are often encountered:
 
 **Overriden methods in subclasses do not get inherited docstrings**
     Please use the :py:func:`horton.utils.doc_inherit` decorator.
+
+**A signature should be added manually to the `__init__` method in Cython**
+    The current behavior of Cython is not compatible with PEP257. The signature gets
+    assigned to the class docstring instead of the __init__ docstring. This is a bug in
+    Cython that should eventually be fixed. See...
+    See https://groups.google.com/forum/#!searchin/cython-users/embedsignature/cython-users/sXtBF2nh5RI/GjcirKOWqBcJ

--- a/horton/cext.pyx
+++ b/horton/cext.pyx
@@ -18,7 +18,6 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 #
 #--
-#cython: embedsignature=True
 '''C++ extensions'''
 
 import numpy as np

--- a/horton/espfit/cext.pyx
+++ b/horton/espfit/cext.pyx
@@ -18,7 +18,6 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 #
 #--
-#cython: embedsignature=True
 '''C++ extensions'''
 
 

--- a/horton/gbasis/cext.pyx
+++ b/horton/gbasis/cext.pyx
@@ -18,7 +18,6 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 #
 #--
-#cython: embedsignature=True
 '''C++ extensions'''
 
 

--- a/horton/grid/cext.pyx
+++ b/horton/grid/cext.pyx
@@ -1186,10 +1186,30 @@ cdef class UniformGrid(object):
         assert shape.shape[0] == 3
         assert pbc.flags['C_CONTIGUOUS']
         assert pbc.shape[0] == 3
-
         self._this = <uniform.UniformGrid*>(new uniform.UniformGrid(
             &origin[0], &grid_rvecs[0, 0], &shape[0], &pbc[0],
         ))
+
+    def __init__(self, np.ndarray[double, ndim=1] origin not None,
+                 np.ndarray[double, ndim=2] grid_rvecs not None,
+                 np.ndarray[long, ndim=1] shape not None,
+                 np.ndarray[long, ndim=1] pbc not None):
+        """__init__(self, ndarray origin, ndarray grid_rvecs, ndarray shape, ndarray pbc)
+        Initialize a UniformGrid instance.
+
+        Parameters
+        ----------
+        origin : np.ndarray[double, ndim=1]
+                 The origin of the uniform grid, where the first grid point is located.
+                 shape=(3,)
+        grid_rvecs : np.ndarray[double, ndim=2]
+                     The rows are real-space basis vectors that define the spacings.
+                     between the grids. shape=(3,3)
+        shape : np.ndarray[long, ndim=1]
+                The shape of the uniform grid, i.e. number of points along each basis.
+        pbc : np.ndarray[long, ndim=1]
+              Three flags (0 or 1) for periodicity along each row in grid_rvecs.
+        """
 
     def __dealloc__(self):
         del self._this

--- a/horton/matrix/cext.pyx
+++ b/horton/matrix/cext.pyx
@@ -18,7 +18,6 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 #
 #--
-#cython: embedsignature=True
 '''C++ extensions for matrix package'''
 
 import numpy as np

--- a/horton/meanfield/cext.pyx
+++ b/horton/meanfield/cext.pyx
@@ -18,7 +18,6 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 #
 #--
-#cython: embedsignature=True
 '''C++ extensions'''
 
 

--- a/horton/quadprog.py
+++ b/horton/quadprog.py
@@ -473,33 +473,27 @@ def solve_radius(a, b, center, radius, r=None, s=None):
 class QPSolver(object):
     '''A Quadratic Programming Solver'''
     def __init__(self, a, b, r=None, s=None, eps=1e-10):
-        r'''
-           The problem is defined as follows;
+        r'''The problem is defined as follows;
 
-           .. math::
-                min_{x} \frac{1}{2} x^T A x - b^T x \\
-                R x = s
-                x \ge 0
+        .. math::
+            \min_x \frac{1}{2} x^T A x - b^T x \\
+            R x = s \\
+            x \ge 0
 
-           **Arguments:**
+        Parameters
+        ----------
 
-           a
-                The symmetric matrix :math:`A \in \mathbb{R}^{n \times n}`
-
-           b
-                The column vector :math:`b \in \mathbb{R}^n`.
-
-           **Optional arguments:**
-
-           r
-                The matrix with constraint coefficients, :math:`R \in \mathbb{R}^{l \times n}`.
-
-           s
-                The matrix with constraint targets, :math:`s \in \mathbb{R}^l`.
-
-           eps
-                A general threshold used for several purposes, e.g. the validity
-                of a solution.
+        a : np.ndarray
+            The symmetric matrix :math:`A \in \mathbb{R}^{n \times n}`
+        b : np.ndarray
+            The column vector :math:`b \in \mathbb{R}^n`.
+        r : np.ndarray or None
+            The matrix with constraint coefficients, :math:`R \in \mathbb{R}^{l \times n}`.
+        s : np.ndarray or None
+            The matrix with constraint targets, :math:`s \in \mathbb{R}^l`.
+        eps : float
+              A general threshold used for several purposes, e.g. the validity of a
+              solution.
         '''
         a, b, r, s = check_constrained_problem(a, b, r, s)
 

--- a/setup.py
+++ b/setup.py
@@ -392,12 +392,14 @@ setup(
             depends=get_depends('horton'),
             include_dirs=[np.get_include(), '.'],
             extra_compile_args=['-std=c++11'],
+            cython_directives={"embedsignature": True},
             language="c++"),
         Extension("horton.matrix.cext",
             sources=get_sources('horton/matrix'),
             depends=get_depends('horton/matrix'),
             include_dirs=[np.get_include(), '.'],
             extra_compile_args=['-std=c++11'],
+            cython_directives={"embedsignature": True},
             language="c++"),
         Extension("horton.gbasis.cext",
             sources=get_sources('horton/gbasis') + ['horton/moments.cpp'],
@@ -416,6 +418,7 @@ setup(
             extra_link_args=libint2_config['extra_link_args'] +
                              blas_config['extra_link_args'],
             define_macros=[blas_precompiler],
+            cython_directives={"embedsignature": True},
             language="c++"),
         Extension("horton.grid.cext",
             sources=get_sources('horton/grid') + [
@@ -436,6 +439,7 @@ setup(
             extra_objects=libxc_config['extra_objects'],
             extra_compile_args=libxc_config['extra_compile_args'] + ['-std=c++11'],
             extra_link_args=libxc_config['extra_link_args'],
+            cython_directives={"embedsignature": True},
             language="c++"),
         Extension("horton.espfit.cext",
             sources=get_sources('horton/espfit') + [
@@ -446,6 +450,7 @@ setup(
                 'horton/grid/uniform.pxd', 'horton/grid/uniform.h'],
             include_dirs=[np.get_include(), '.'],
             extra_compile_args=['-std=c++11'],
+            cython_directives={"embedsignature": True},
             language="c++"),
     ],
     headers=get_headers(),


### PR DESCRIPTION
- Move the embedsignature option to setup.py, such that it is less
  easily forgotten for new extension modules.
- Change autoclass_content to "init" in conf.py. Not great but least bad
  option we have.
- Document the constructor of UniformGrid, coping with limitations in
  Cython.
- Also update documentation of QPSolver constructor to Numpy style, just
  to see if that still works semi-nicely.