### PR TITLE
Some minor modifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ depends/*.*
 # Ignore user configuration for libraries
 setup.cfg
 
+# Ignore mac .DS_Store
+.DS_Store
+
 # Ignore testing output
 .coverage
 qaworkdir

--- a/AUTHORS
+++ b/AUTHORS
@@ -11,6 +11,7 @@ Paul W. Ayers <ayers@mcmaster.ca>
 Pawel Tecmer <ptecmer@gmail.com>
 Peter A. Limacher <limach@mcmaster.ca>
 Steven Vandenbrande <Steven.Vandenbrande@UGent.be>
+Stijn Fias <stijn.fias@gmail.com>
 Taewon D. Kim <kimt33@mcmaster.ca>
 Toon Verstraelen <Toon.Verstraelen@UGent.be>
 Yilin Zhao <zhao229@mcmaster.ca>

--- a/data/examples/hamiltonian/even_tempered_li.py
+++ b/data/examples/hamiltonian/even_tempered_li.py
@@ -13,7 +13,7 @@ lnratio = (np.log(alpha_high) - np.log(alpha_low))/(nbasis-1)
 # contraction only contains one basis function.
 bcs = []
 for ibasis in xrange(nbasis):
-    alpha = alpha_low**lnratio
+    alpha = alpha_low * np.exp(lnratio * ibasis)
     # arguments of GOBasisContraction:
     #     shell_type, list of exponents, list of contraction coefficients
     bcs.append(GOBasisContraction(0, np.array([alpha]), np.array([1.0])))

--- a/data/setup_cfgs/setup.Darwin-10.10.4-x86_64.cfg
+++ b/data/setup_cfgs/setup.Darwin-10.10.4-x86_64.cfg
@@ -1,0 +1,11 @@
+[libxc]
+include_dirs=/opt/local/include/
+libraries=xc
+
+[libint2]
+include_dirs=/opt/local/include/libint2
+libraries=int2
+
+[blas]
+include_dirs=/opt/local/include/
+libraries=atlas

--- a/data/setup_cfgs/setup.Darwin-10.10.5-x86_64.cfg
+++ b/data/setup_cfgs/setup.Darwin-10.10.5-x86_64.cfg
@@ -1,0 +1,11 @@
+[libxc]
+include_dirs=/opt/local/include/
+libraries=xc
+
+[libint2]
+include_dirs=/opt/local/include/libint2
+libraries=int2
+
+[blas]
+include_dirs=/opt/local/include/
+libraries=atlas

--- a/data/setup_cfgs/setup.Darwin-10.11.0-x86_64.cfg
+++ b/data/setup_cfgs/setup.Darwin-10.11.0-x86_64.cfg
@@ -1,0 +1,11 @@
+[libxc]
+include_dirs=/opt/local/include/
+libraries=xc
+
+[libint2]
+include_dirs=/opt/local/include/libint2
+libraries=int2
+
+[blas]
+include_dirs=/opt/local/include/
+libraries=atlas

--- a/data/setup_cfgs/setup.Darwin-10.11.1-x86_64.cfg
+++ b/data/setup_cfgs/setup.Darwin-10.11.1-x86_64.cfg
@@ -1,0 +1,11 @@
+[libxc]
+include_dirs=/opt/local/include/
+libraries=xc
+
+[libint2]
+include_dirs=/opt/local/include/libint2
+libraries=int2
+
+[blas]
+include_dirs=/opt/local/include/
+libraries=atlas

--- a/data/setup_cfgs/setup.Darwin-10.11.2-x86_64.cfg
+++ b/data/setup_cfgs/setup.Darwin-10.11.2-x86_64.cfg
@@ -1,0 +1,11 @@
+[libxc]
+include_dirs=/opt/local/include/
+libraries=xc
+
+[libint2]
+include_dirs=/opt/local/include/libint2
+libraries=int2
+
+[blas]
+include_dirs=/opt/local/include/
+libraries=atlas

--- a/data/setup_cfgs/setup.Darwin-10.11.3-x86_64.cfg
+++ b/data/setup_cfgs/setup.Darwin-10.11.3-x86_64.cfg
@@ -1,0 +1,11 @@
+[libxc]
+include_dirs=/opt/local/include/
+libraries=xc
+
+[libint2]
+include_dirs=/opt/local/include/libint2
+libraries=int2
+
+[blas]
+include_dirs=/opt/local/include/
+libraries=atlas

--- a/data/setup_cfgs/setup.Darwin-10.11.4-x86_64.cfg
+++ b/data/setup_cfgs/setup.Darwin-10.11.4-x86_64.cfg
@@ -1,0 +1,11 @@
+[libxc]
+include_dirs=/opt/local/include/
+libraries=xc
+
+[libint2]
+include_dirs=/opt/local/include/libint2
+libraries=int2
+
+[blas]
+include_dirs=/opt/local/include/
+libraries=atlas

--- a/data/setup_cfgs/setup.Darwin-10.11.5-x86_64.cfg
+++ b/data/setup_cfgs/setup.Darwin-10.11.5-x86_64.cfg
@@ -1,0 +1,11 @@
+[libxc]
+include_dirs=/opt/local/include/
+libraries=xc
+
+[libint2]
+include_dirs=/opt/local/include/libint2
+libraries=int2
+
+[blas]
+include_dirs=/opt/local/include/
+libraries=atlas

--- a/doc/tech_dev_git.rst
+++ b/doc/tech_dev_git.rst
@@ -158,6 +158,8 @@ There is also a web interface to HORTON's git repository:
 https://github.com/theochem/horton
 
 
+.. _ref_build_refatoms:
+
 Additional steps required to build the development version of HORTON
 ====================================================================
 

--- a/doc/user_download_and_install_linux.rst.template
+++ b/doc/user_download_and_install_linux.rst.template
@@ -208,16 +208,10 @@ This file is located in either ``${HOME}/.matplotlib`` or
 Reference atoms
 ===============
 
-This step can be skipped when compiling a stable release from a .tar.gz file
-because these stable releases already contain the reference atoms.
-
-Several parts of Horton make use of reference atomic computations. These files
-are too large to be included in the git revision system. Therefore, they must be
-downloaded separately when compiling a development version of Horton::
-
-    cd data/refatoms
-    make all
-    cd ../..
+Several parts of HORTON make use of reference atomic computations. When compiling
+a stable release from a .tar.gz file these reference atoms are already included in
+the release. When building a development version of HORTON, please refer to
+:ref:`ref_build_refatoms` on how to build these reference atoms.
 
 
 Running the tests

--- a/doc/user_download_and_install_linux.rst.template
+++ b/doc/user_download_and_install_linux.rst.template
@@ -205,6 +205,21 @@ This file is located in either ``${HOME}/.matplotlib`` or
 ``${HOME}/.config/matplotlib``.
 
 
+Reference atoms
+===============
+
+This step can be skipped when compiling a stable release from a .tar.gz file
+because these stable releases already contain the reference atoms.
+
+Several parts of Horton make use of reference atomic computations. These files
+are too large to be included in the git revision system. Therefore, they must be
+downloaded separately when compiling a development version of Horton::
+
+    cd data/refatoms
+    make all
+    cd ../..
+
+
 Running the tests
 =================
 

--- a/doc/user_download_and_install_mac.rst.template
+++ b/doc/user_download_and_install_mac.rst.template
@@ -21,13 +21,13 @@
 
 ${big_fat_warning}
 
-Download and installation on Mac OS X (10.8--10.10)
+Download and installation on Mac OS X (10.8--10.11)
 ###################################################
 
 Disclaimer
 ==========
 
-HORTON has been tested on Mac OS X 10.8--10.10 using MacPorts. If you
+HORTON has been tested on Mac OS X 10.8--10.11 using MacPorts. If you
 are running any other version of OS X or if you are using other package
 managers, some of the instructions below may not work.
 
@@ -156,7 +156,7 @@ build LibXC, which will work on most systems:
     ${custom_install_libxc}
 
 This results in a LibXC library suitable for compiling HORTON. If this fails,
-consult your local Linux guru to build LibXC. For more info about LibXC, check
+consult your local Mac guru to build LibXC. For more info about LibXC, check
 the website: http://www.tddft.org/programs/octopus/wiki/index.php/Libxc
 
 **LibInt2**
@@ -169,7 +169,7 @@ build LibInt2, which will work on most systems:
     ${custom_install_libint}
 
 The compilation of LibInt2 takes a few minutes and results in a library suitable for
-compiling HORTON. If this fails, consult your local Linux guru to build LibInt2. For more
+compiling HORTON. If this fails, consult your local Mac guru to build LibInt2. For more
 info about LibInt2, check the website: http://sourceforge.net/p/libint/home
 
 
@@ -185,9 +185,9 @@ The regular build and install is done as follows:
 
     ./setup.py install --user
 
-The ``setup.py`` script makes a reasonable attemp configuring the compiler and
+The ``setup.py`` script makes a reasonable attempt configuring the compiler and
 linker settings for the LibXC, LibInt2 and BLAS libraries. However, this does
-not work in all environments. In case of a faillure, or if a configuration other
+not work in all environments. In case of a failure, or if a configuration other
 than the default is desired, read the following section.
 
 
@@ -221,6 +221,21 @@ following line to your ``matplotlibrc`` file:
 
 This file is located either in ``${HOME}/.matplotlib`` or
 ``${HOME}/.config/matplotlib``.
+
+
+Reference atoms
+===============
+
+This step can be skipped when compiling a stable release from a .tar.gz file
+because these stable releases already contain the reference atoms.
+
+Several parts of Horton make use of reference atomic computations. These files
+are too large to be included in the git revision system. Therefore, they must be
+downloaded separately when compiling a development version of Horton::
+
+    cd data/refatoms
+    make all
+    cd ../..
 
 
 Running the tests

--- a/doc/user_download_and_install_mac.rst.template
+++ b/doc/user_download_and_install_mac.rst.template
@@ -226,16 +226,10 @@ This file is located either in ``${HOME}/.matplotlib`` or
 Reference atoms
 ===============
 
-This step can be skipped when compiling a stable release from a .tar.gz file
-because these stable releases already contain the reference atoms.
-
-Several parts of Horton make use of reference atomic computations. These files
-are too large to be included in the git revision system. Therefore, they must be
-downloaded separately when compiling a development version of Horton::
-
-    cd data/refatoms
-    make all
-    cd ../..
+Several parts of HORTON make use of reference atomic computations. When compiling
+a stable release from a .tar.gz file these reference atoms are already included in
+the release. When building a development version of HORTON, please refer to
+:ref:`ref_build_refatoms` on how to build these reference atoms.
 
 
 Running the tests

--- a/doc/user_estruct_hf_dft.rst
+++ b/doc/user_estruct_hf_dft.rst
@@ -92,7 +92,7 @@ completely neglects electron-electron interactions. The orbitals for such a
 one-body Hamiltonian can be computed without any prior guess.
 
 The function :py:func:`~horton.meanfield.guess.guess_core_hamiltonian` can be
-used to compute the core hamiltonian guess. This type of guess does only relies on a
+used to compute the core hamiltonian guess. This type of guess only relies on a
 simple one-body Hamiltonian, usually consisting of the kinetic energy and the
 interaction with the external field. In case of an unrestricted calculation,
 this means that the same initial orbital guess is made for the alpha and beta
@@ -379,7 +379,7 @@ Choose an orbital occupation scheme
 ===================================
 
 Before calling an SCF solver, you have to select a scheme to set the orbital
-occupations after each SCF iteration, even when the occuption numbers are to
+occupations after each SCF iteration, even when the occupation numbers are to
 remain fixed throughout the calculation. You can use any of the following
 three options:
 
@@ -574,7 +574,7 @@ Preparing for a Post-Hartree-Fock calculation
 Once the SCF has converged and you have obtained a set of orbitals, you can use
 these orbitals to convert the integrals from the atomic-orbital (AO) basis to
 the molecular-orbital (MO) basis. Two implementations are available in HORTON:
-(i) using all molecular orbitals or (ii) by specifing a frozen core and active
+(i) using all molecular orbitals or (ii) by specifying a frozen core and active
 set of orbitals. A full example, ``rhf_n2_dense.py``, which covers both options
 and which includes dumping the transformed integrals to a file, is given in the
 section :ref:`hf_dft_complete_examples` below.
@@ -664,7 +664,7 @@ used in which example.
 .. include:: hf_dft_examples.rst.inc
 
 A more elaborate example can be found in ``data/examples/hf_compare``. It
-contains a script that systemtically computes all elements in the periodic table
+contains a script that systematically computes all elements in the periodic table
 (for different charges and multiplicities), and compares the results with
 outputs obtained with Gaussian. See the ``README`` file for instructions how to
 run this example.

--- a/doc/user_hamiltonian_model.rst
+++ b/doc/user_hamiltonian_model.rst
@@ -96,7 +96,7 @@ The the on-site repulsion :math:`U` is calculated using the method
 
     onsite = modelham.compute_er(lf, U)
 
-Finally, all terms of the 1-dimensinal Hubbard Hamiltonian are combined together
+Finally, all terms of the 1-dimensional Hubbard Hamiltonian are combined together
 and passed to the effective Hamiltonian class, :py:class:`~horton.meanfield.hamiltonian.REffHam`,
 which can then be passed to the restricted Hartree-Fock or DFT modules,
 

--- a/doc/user_other_matrix.rst
+++ b/doc/user_other_matrix.rst
@@ -122,7 +122,7 @@ with the different `backend` modules available. For example, instead of the
 
     lf = CholeskyLinalgFactory()
 
-Making this change will not change any of the preceeding code, provided that the
+Making this change will not change any of the preceding code, provided that the
 same methods and attributes are implemented in this module as well.
 
 Many functions and classes have been implemented into the ``matrix`` package. It


### PR DESCRIPTION
I made some small modifications that came up when installing the latest version of HORTON on my Mac and when going through the documentation:

- I added setup.Darwin-10.10.4-x86_64.cfg => setup.Darwin-10.11.5-x86_64.cfg to keep the files up to date
- I added the mac .DS_Store to .gitignore I have git ignore it system-wide, but if a user doesn't have this set up he will get a Fail for the horton.test.test_context.test_data_files nosiest
- Made some more minor modifications to the docs, mostly typo's but I also added how to set up the reference atoms if the user isn't installing from the .tar.gz file
- there was a mistake in even_tempered_li.py, which created just 30 times a gaussian with the same coefficient. I fixed this.

 