### PR TITLE
Also copy trapdoor.py in simulate_trapdoor_pr.py

### DIFF
--- a/tools/qa/simulate_trapdoor_pr.py
+++ b/tools/qa/simulate_trapdoor_pr.py
@@ -218,6 +218,7 @@ def trapdoor_workflow(repo, script, qaworkdir, skip_ancestor):
     else:
         copied_script = os.path.join(qaworkdir, os.path.basename(script))
         shutil.copy(script, copied_script)
+        shutil.copy('tools/qa/trapdoor.py', os.path.join(qaworkdir, 'trapdoor.py'))
         # Check out the master branch. (We should be constructing the ancestor etc. but
         # that should come down to the same thing for a PR.)
         repo.heads.master.checkout()


### PR DESCRIPTION
Small fix for problem with `simulate_trapdoor_pr.py` in case of a clean `qaworkdir`. 