### PR TITLE
Default of 3.0 Bohr covalent radius in Becke grid

### DIFF
--- a/horton/grid/molgrid.py
+++ b/horton/grid/molgrid.py
@@ -117,7 +117,9 @@ class BeckeMolGrid(IntGrid):
 
         if mode != 'only':
             # More recent covalent radii are used than in the original work of Becke.
-            cov_radii = np.array([periodic[n].cov_radius for n in self.numbers])
+            # No covalent radius is defined for elements heavier than Curium and a
+            # default value of 3.0 Bohr is used for heavier elements.
+            cov_radii = np.array([(periodic[n].cov_radius or 3.0) for n in self.numbers])
 
         # The actual work:
         if log.do_medium:

--- a/horton/grid/test/test_molgrid.py
+++ b/horton/grid/test/test_molgrid.py
@@ -70,6 +70,17 @@ def test_integrate_hydrogen_trimer_1s():
     assert abs(occupation - 3.0) < 1e-3
 
 
+def test_all_elements():
+    numbers = np.array([1, 118], int)
+    coordinates = np.array([[0.0, 0.0, -1.0], [0.0, 0.0, 1.0]], float)
+    rtf = ExpRTransform(1e-3, 1e1, 10)
+    rgrid = RadialGrid(rtf)
+    while numbers[0] < numbers[1]:
+        BeckeMolGrid(coordinates, numbers, None, (rgrid, 110), random_rotate=False)
+        numbers[0] += 1
+        numbers[1] -= 1
+
+
 def test_molgrid_attrs_subgrid():
     numbers = np.array([6, 8], int)
     coordinates = np.array([[0.0, 0.2, -0.5], [0.1, 0.0, 0.5]], float)


### PR DESCRIPTION
Simple change. Includes a test to verify that a BeckeMolGrid can be created with any elements present in the molecule.