### PR TITLE
Fix workaround cython 0.24

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -87,7 +87,7 @@
 }, {
     "name": "cython",
     "title": "Cython",
-    "version_requirement": ">=0.17.1,!=0.24",
+    "version_requirement": ">=0.17.1",
     "version_command": "cython --version",
     "homepage": "http://www.cython.org/",
     "fedora_24_rpm": "Cython",

--- a/doc/releaseinfo.py
+++ b/doc/releaseinfo.py
@@ -14,7 +14,7 @@ def transform_git_date(s):
 def get_releaseinfo():
     """Retrieve release info from git and also write releaseinfo.json."""
     # Default values in case the git commands don't work
-    version = '2.1.0b1'
+    version = '2.1.0b2'
     describe = '%s-nogit' % version
     release_date = '??? ??, ????'
     doc_release_date = release_date

--- a/doc/user_download_and_install_linux.rst.template
+++ b/doc/user_download_and_install_linux.rst.template
@@ -37,7 +37,7 @@ Download the code
 
 The latest stable source code release of HORTON can be downloaded here:
 
-    https://github.com/theochem/horton/releases/download/2.1.0b1/horton-2.1.0b1.tar.gz
+    https://github.com/theochem/horton/releases/download/2.1.0b2/horton-2.1.0b2.tar.gz
 
 Choose a suitable directory, e.g. ``~/build``, download and unpack the archive
 
@@ -45,9 +45,9 @@ Choose a suitable directory, e.g. ``~/build``, download and unpack the archive
 
     mkdir -p ~/build
     cd ~/build
-    curl -kLO https://github.com/theochem/horton/releases/download/2.1.0b1/horton-2.1.0b1.tar.gz
-    tar -xvzf horton-2.1.0b1.tar.gz
-    cd horton-2.1.0b1
+    curl -kLO https://github.com/theochem/horton/releases/download/2.1.0b2/horton-2.1.0b2.tar.gz
+    tar -xvzf horton-2.1.0b2.tar.gz
+    cd horton-2.1.0b2
 
 
 Dependencies for building, installing and testing HORTON

--- a/doc/user_download_and_install_mac.rst.template
+++ b/doc/user_download_and_install_mac.rst.template
@@ -95,7 +95,7 @@ Download the code
 
 The latest stable source code release of HORTON can be downloaded here:
 
-    https://github.com/theochem/horton/releases/download/2.1.0b1/horton-2.1.0b1.tar.gz
+    https://github.com/theochem/horton/releases/download/2.1.0b2/horton-2.1.0b2.tar.gz
 
 Choose a suitable directory, e.g. ``~/build``, download and unpack the archive:
 
@@ -103,9 +103,9 @@ Choose a suitable directory, e.g. ``~/build``, download and unpack the archive:
 
     mkdir -p ~/build
     cd ~/build
-    curl -kLO https://github.com/theochem/horton/releases/download/2.1.0b1/horton-2.1.0b1.tar.gz
-    tar -xvzf horton-2.1.0b1.tar.gz
-    cd horton-2.1.0b1
+    curl -kLO https://github.com/theochem/horton/releases/download/2.1.0b2/horton-2.1.0b2.tar.gz
+    tar -xvzf horton-2.1.0b2.tar.gz
+    cd horton-2.1.0b2
 
 
 Dependencies for building, installing and testing HORTON

--- a/horton/__init__.py
+++ b/horton/__init__.py
@@ -21,7 +21,7 @@
 '''The main HORTON Package'''
 
 
-__version__ = '2.1.0b1'
+__version__ = '2.1.0b2'
 
 
 # Extensions are imported first to call fpufix as early as possible

--- a/horton/gbasis/cext.pyx
+++ b/horton/gbasis/cext.pyx
@@ -116,7 +116,7 @@ def cart_to_pure_low(np.ndarray[double] work_cart not None,
 
 def compute_cholesky(GOBasis gobasis, GB4Integral gb4int, double threshold=1e-8, lf = None):
     cdef gbw.GB4IntegralWrapper* gb4w = NULL
-    cdef vector[np.float64_t]* vectors = NULL
+    cdef vector[double]* vectors = NULL
     cdef np.npy_intp dims[3]
     cdef np.ndarray result
 
@@ -126,7 +126,7 @@ def compute_cholesky(GOBasis gobasis, GB4Integral gb4int, double threshold=1e-8,
     try:
         gb4w = new gbw.GB4IntegralWrapper(<gbasis.GOBasis*> gobasis._this,
                                           <ints.GB4Integral*> gb4int._this)
-        vectors = new vector[np.float64_t]()
+        vectors = new vector[double]()
         nvec = cholesky.cholesky(gb4w, vectors, threshold)
         dims[0] = <np.npy_intp> nvec
         dims[1] = <np.npy_intp> gobasis.nbasis

--- a/setup.py
+++ b/setup.py
@@ -466,7 +466,7 @@ for e in ext_modules:
 
 setup(
     name='horton',
-    version='2.1.0b1',
+    version='2.1.0b2',
     description='HORTON: Helpful Open-source Research TOol for N-fermion systems.',
     author='Toon Verstraelen',
     author_email='Toon.Verstraelen@UGent.be',


### PR DESCRIPTION
This change makes the gbasis extension compile with Cython 0.24. The problem is a silly bug in Cython 0.24, which got fixed in 0.24.1. However, 0.24 seems to be widespread, so this small change seems reasonable to facilitate compilation for users that cannot easily upgrade Cython.