### PR TITLE
Update WFN parser to load energy 

### DIFF
--- a/doc/tech_ref_file_formats.rst
+++ b/doc/tech_ref_file_formats.rst
@@ -258,7 +258,7 @@ Dump                     No
 Recognized by            File extension ``.wfn``
 Interoperation           `GAMESS <http://www.msg.ameslab.gov/gamess/>`_,
                          `Gaussian <http://www.gaussian.com/>`_,
-Always **loading**       ``title`` ``coordinates`` ``numbers`` ``obasis`` ``exp_alpha``
+Always **loading**       ``title`` ``coordinates`` ``numbers`` ``obasis`` ``exp_alpha`` ``energy``
 **loading** if present   ``exp_beta``
 Derived when **loading** ``natom``
 ======================== =======================================================

--- a/horton/io/test/test_wfn.py
+++ b/horton/io/test/test_wfn.py
@@ -20,10 +20,7 @@
 # --
 
 import numpy as np
-import os
-
 from horton import *  # pylint: disable=wildcard-import,unused-wildcard-import
-
 from horton.io.test.common import compute_mulliken_charges, compute_hf_energy
 
 
@@ -34,7 +31,7 @@ def test_load_wfn_low_he_s():
     assert title == 'He atom - decontracted 6-31G basis set'
     assert numbers.shape == (1,)
     assert numbers == [2]
-    assert coordinates.shape == (1,3)
+    assert coordinates.shape == (1, 3)
     assert (coordinates == [0.00, 0.00, 0.00]).all()
     assert centers.shape == (4,)
     assert (centers == [0, 0, 0, 0]).all()
@@ -49,7 +46,8 @@ def test_load_wfn_low_he_s():
     assert mo_energy.shape == (1,)
     assert mo_energy == [-0.914127]
     assert coefficients.shape == (4, 1)
-    assert (coefficients == np.array([0.26139500E+00, 0.41084277E+00, 0.39372947E+00, 0.14762025E+00]).reshape(4,1)).all()
+    expected = np.array([0.26139500E+00, 0.41084277E+00, 0.39372947E+00, 0.14762025E+00])
+    assert (coefficients == expected.reshape(4, 1)).all()
 
 
 def test_load_wfn_low_h2O():
@@ -71,7 +69,7 @@ def test_load_wfn_low_h2O():
     assert (type_assignment[6:15] == np.array([2, 2, 2, 3, 3, 3, 4, 4, 4])).all()
     assert (type_assignment[15:] == np.ones(6)).all()
     assert exponents.shape == (21,)
-    assert (exponents[ :3] == [0.1307093E+03, 0.2380887E+02, 0.6443608E+01]).all()
+    assert (exponents[:3] == [0.1307093E+03, 0.2380887E+02, 0.6443608E+01]).all()
     assert (exponents[5:8] == [0.3803890E+00, 0.5033151E+01, 0.1169596E+01]).all()
     assert (exponents[13:16] == [0.1169596E+01, 0.3803890E+00, 0.3425251E+01]).all()
     assert exponents[-1] == 0.1688554E+00
@@ -83,58 +81,94 @@ def test_load_wfn_low_h2O():
     assert mo_energy.shape == (5,)
     assert (mo_energy == np.sort(mo_energy)).all()
     assert (mo_energy[:3] == [-20.251576, -1.257549, -0.593857]).all()
-    assert (mo_energy[3:] == [ -0.459729, -0.392617]).all()
+    assert (mo_energy[3:] == [-0.459729, -0.392617]).all()
     assert coefficients.shape == (21, 5)
-    assert (coefficients[0] == [0.42273517E+01, -0.99395832E+00, 0.19183487E-11, 0.44235381E+00, -0.57941668E-14]).all()
-    assert coefficients[ 6, 2] ==  0.83831599E+00
-    assert coefficients[10, 3] ==  0.65034846E+00
-    assert coefficients[17, 1] ==  0.12988055E-01
+    expected = [0.42273517E+01, -0.99395832E+00, 0.19183487E-11, 0.44235381E+00, -0.57941668E-14]
+    assert (coefficients[0] == expected).all()
+    assert coefficients[6, 2] == 0.83831599E+00
+    assert coefficients[10, 3] == 0.65034846E+00
+    assert coefficients[17, 1] == 0.12988055E-01
     assert coefficients[-1, 0] == -0.46610858E-03
-    assert coefficients[-1,-1] == -0.33277355E-15
+    assert coefficients[-1, -1] == -0.33277355E-15
 
 
-def test_setup_permutation1():
-    assert (setup_permutation1(np.array([1, 1, 1])) == [0, 1, 2]).all()
-    assert (setup_permutation1(np.array([1, 1, 2, 3, 4])) == [0, 1, 2, 3, 4]).all()
-    assert (setup_permutation1(np.array([2, 3, 4])) == [0, 1, 2]).all()
-    assert (setup_permutation1(np.array([2, 2, 3, 3, 4, 4])) == [0, 2, 4, 1, 3, 5]).all()
-    assert (setup_permutation1(np.array([1, 1, 2, 2, 3, 3, 4, 4, 1])) == [0, 1, 2, 4, 6, 3, 5, 7, 8]).all()
-    assert (setup_permutation1(np.array([1, 5, 6, 7, 8, 9, 10, 1])) == [0, 1, 2, 3, 4, 5, 6, 7]).all()
-    assert (setup_permutation1(np.array([5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10])) == [0, 2, 4, 6, 8, 10, 1, 3, 5, 7, 9, 11]).all()
-    assert (setup_permutation1(np.array([1, 2, 2, 3, 3, 4, 4, 5, 6, 7, 8, 9, 10])) == [0, 1, 3, 5, 2, 4, 6, 7, 8, 9, 10, 11, 12]).all()
-    assert (setup_permutation1(np.array([11, 12, 13, 17, 14, 15, 18, 19, 16, 20])) == range(10)).all() # f orbitals
-    assert (setup_permutation1(np.array([23, 29, 32, 27, 22, 28, 35, 34, 26, 31, 33, 30, 25, 24, 21])) == range(15)).all() # g orbitals
-    assert (setup_permutation1(np.array([23, 29, 32, 27, 22, 28, 35, 34, 26, 31, 33, 30, 25, 24, 21])) == range(15)).all() # g orbitals
-    assert (setup_permutation1(np.arange(36, 57)) == range(21)).all() # h orbitals
-    assert (setup_permutation1(np.array([1, 1, 11, 12, 13, 17, 14, 15, 18, 19, 16, 20])) == range(12)).all()
-    assert (setup_permutation1(np.array([2, 3, 4, 11, 12, 13, 17, 14, 15, 18, 19, 16, 20, 1, 1])) == range(15)).all()
+def test_get_permutation_orbital():
+    assert (get_permutation_orbital(np.array([1, 1, 1])) == [0, 1, 2]).all()
+    assert (get_permutation_orbital(np.array([1, 1, 2, 3, 4])) == [0, 1, 2, 3, 4]).all()
+    assert (get_permutation_orbital(np.array([2, 3, 4])) == [0, 1, 2]).all()
+    assert (get_permutation_orbital(np.array([2, 2, 3, 3, 4, 4])) == [0, 2, 4, 1, 3, 5]).all()
+    assign = np.array([1, 1, 2, 2, 3, 3, 4, 4, 1])
+    expect = [0, 1, 2, 4, 6, 3, 5, 7, 8]
+    assert (get_permutation_orbital(assign) == expect).all()
+    assign = np.array([1, 5, 6, 7, 8, 9, 10, 1])
+    expect = [0, 1, 2, 3, 4, 5, 6, 7]
+    assert (get_permutation_orbital(assign) == expect).all()
+    assign = np.array([5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10])
+    expect = [0, 2, 4, 6, 8, 10, 1, 3, 5, 7, 9, 11]
+    assert (get_permutation_orbital(assign) == expect).all()
+    assign = np.array([1, 2, 2, 3, 3, 4, 4, 5, 6, 7, 8, 9, 10])
+    expect = [0, 1, 3, 5, 2, 4, 6, 7, 8, 9, 10, 11, 12]
+    assert (get_permutation_orbital(assign) == expect).all()
+    # f orbitals
+    assign = np.array([11, 12, 13, 17, 14, 15, 18, 19, 16, 20])
+    assert (get_permutation_orbital(assign) == range(10)).all()
+    # g orbitals
+    assign = np.array([23, 29, 32, 27, 22, 28, 35, 34, 26, 31, 33, 30, 25, 24, 21])
+    assert (get_permutation_orbital(assign) == range(15)).all()
+    # g orbitals
+    assign = np.array([23, 29, 32, 27, 22, 28, 35, 34, 26, 31, 33, 30, 25, 24, 21])
+    assert (get_permutation_orbital(assign) == range(15)).all()
+    # h orbitals
+    assert (get_permutation_orbital(np.arange(36, 57)) == range(21)).all()
+    assign = np.array([1, 1, 11, 12, 13, 17, 14, 15, 18, 19, 16, 20])
+    assert (get_permutation_orbital(assign) == range(12)).all()
+    assign = np.array([2, 3, 4, 11, 12, 13, 17, 14, 15, 18, 19, 16, 20, 1, 1])
+    assert (get_permutation_orbital(assign) == range(15)).all()
 
 
-def test_setup_permutation2():
-    assert (setup_permutation2(np.array([1, 1, 1])) == [0, 1, 2]).all()
-    assert (setup_permutation2(np.array([2, 2, 3, 3, 4, 4])) == [0, 2, 4, 1, 3, 5]).all()
-    assert (setup_permutation2(np.array([1, 2, 3, 4, 1])) == [0, 1, 2, 3, 4]).all()
-    assert (setup_permutation2(np.array([5, 6, 7, 8, 9, 10])) == [0, 3, 4, 1, 5, 2]).all()
-    assert (setup_permutation2(np.repeat([5, 6, 7, 8, 9, 10], 2)) == [0, 6, 8, 2, 10, 4, 1, 7, 9, 3, 11, 5]).all()
-    assert (setup_permutation2(np.arange(1, 11)) == [0, 1, 2, 3, 4, 7, 8, 5, 9, 6]).all()
-    assert (setup_permutation2(np.array([1, 5, 6, 7, 8, 9, 10, 1])) == [0, 1, 4, 5, 2, 6, 3, 7]).all()
-    assert (setup_permutation2(np.array([11, 12, 13, 17, 14, 15, 18, 19, 16, 20])) == [0, 4, 5, 3, 9, 6, 1, 8, 7, 2]).all()
-    assert (setup_permutation2(np.array([1, 11, 12, 13, 17, 14, 15, 18, 19, 16, 20, 1])) == [0, 1, 5, 6, 4, 10, 7, 2, 9, 8, 3, 11]).all()
-    assert (setup_permutation2(np.array([1, 11, 12, 13, 17, 14, 15, 18, 19, 16, 20, 2, 2, 3, 3, 4, 4])) == [0, 1, 5, 6, 4, 10, 7, 2, 9, 8, 3, 11, 13, 15, 12, 14, 16]).all()
-    assert (setup_permutation2(np.array([1, 11, 12, 13, 17, 14, 15, 18, 19, 16, 20, 2, 3, 4, 5, 6, 7, 8, 9, 10])) == [0, 1, 5, 6, 4, 10, 7, 2, 9, 8, 3, 11, 12, 13, 14, 17, 18, 15, 19, 16]).all()
-    assert (setup_permutation2(np.arange(36, 57)) == np.arange(21)[::-1]).all()
-    assert (setup_permutation2(np.array([23, 29, 32, 27, 22, 28, 35, 34, 26, 31, 33, 30, 25, 24, 21])) == [14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]).all()
-    assert (setup_permutation2(np.arange(36, 57)) == range(21)[::-1]).all()
+def test_get_permutation_basis():
+    assert (get_permutation_basis(np.array([1, 1, 1])) == [0, 1, 2]).all()
+    assert (get_permutation_basis(np.array([2, 2, 3, 3, 4, 4])) == [0, 2, 4, 1, 3, 5]).all()
+    assert (get_permutation_basis(np.array([1, 2, 3, 4, 1])) == [0, 1, 2, 3, 4]).all()
+    assert (get_permutation_basis(np.array([5, 6, 7, 8, 9, 10])) == [0, 3, 4, 1, 5, 2]).all()
+    assign = np.repeat([5, 6, 7, 8, 9, 10], 2)
+    expect = [0, 6, 8, 2, 10, 4, 1, 7, 9, 3, 11, 5]
+    assert (get_permutation_basis(assign) == expect).all()
+    assert (get_permutation_basis(np.arange(1, 11)) == [0, 1, 2, 3, 4, 7, 8, 5, 9, 6]).all()
+    assign = np.array([1, 5, 6, 7, 8, 9, 10, 1])
+    expect = [0, 1, 4, 5, 2, 6, 3, 7]
+    assert (get_permutation_basis(assign) == expect).all()
+    assign = np.array([11, 12, 13, 17, 14, 15, 18, 19, 16, 20])
+    expect = [0, 4, 5, 3, 9, 6, 1, 8, 7, 2]
+    assert (get_permutation_basis(assign) == expect).all()
+    assign = np.array([1, 11, 12, 13, 17, 14, 15, 18, 19, 16, 20, 1])
+    expect = [0, 1, 5, 6, 4, 10, 7, 2, 9, 8, 3, 11]
+    assert (get_permutation_basis(assign) == expect).all()
+    assign = np.array([1, 11, 12, 13, 17, 14, 15, 18, 19, 16, 20, 2, 2, 3, 3, 4, 4])
+    expect = [0, 1, 5, 6, 4, 10, 7, 2, 9, 8, 3, 11, 13, 15, 12, 14, 16]
+    assert (get_permutation_basis(assign) == expect).all()
+    assign = [1, 11, 12, 13, 17, 14, 15, 18, 19, 16, 20, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    expect = np.array([0, 1, 5, 6, 4, 10, 7, 2, 9, 8, 3, 11, 12, 13, 14, 17, 18, 15, 19, 16])
+    assert (get_permutation_basis(np.array(assign)) == expect).all()
+    assert (get_permutation_basis(np.arange(36, 57)) == np.arange(21)[::-1]).all()
+    assign = [23, 29, 32, 27, 22, 28, 35, 34, 26, 31, 33, 30, 25, 24, 21]
+    expect = [14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+    assert (get_permutation_basis(np.array(assign)) == expect).all()
+    assert (get_permutation_basis(np.arange(36, 57)) == range(21)[::-1]).all()
 
 
-def test_setup_mask():
-    assert (setup_mask(np.array([2, 3, 4])) == [True, False, False]).all()
-    assert (setup_mask(np.array([1, 2, 3, 4, 1, 2, 3, 4])) == [True, True, False, False, True, True, False, False]).all()
-    assert (setup_mask(np.array([5, 6, 7, 8, 9, 10])) == [True, False, False, False, False, False]).all()
-    assert (setup_mask(np.array([2, 3, 4, 1, 5, 6, 7, 8, 9, 10])) == [True, False, False, True, True, False, False, False, False, False]).all()
-    assert (setup_mask(np.arange(11, 21)) == [True, False, False, False, False, False, False, False, False, False]).all()
-    assert (setup_mask(np.array([21, 24, 25])) == [True, False, False]).all()
-    assert (setup_mask(np.array([11, 21, 36, 1])) == [True, True, True, True]).all()
+def test_get_mask():
+    assert (get_mask(np.array([2, 3, 4])) == [True, False, False]).all()
+    expected = [True, True, False, False, True, True, False, False]
+    assert (get_mask(np.array([1, 2, 3, 4, 1, 2, 3, 4])) == expected).all()
+    expected = [True, False, False, False, False, False]
+    assert (get_mask(np.array([5, 6, 7, 8, 9, 10])) == expected).all()
+    expected = [True, False, False, True, True, False, False, False, False, False]
+    assert (get_mask(np.array([2, 3, 4, 1, 5, 6, 7, 8, 9, 10])) == expected).all()
+    expected = [True, False, False, False, False, False, False, False, False, False]
+    assert (get_mask(np.arange(11, 21)) == expected).all()
+    assert (get_mask(np.array([21, 24, 25])) == [True, False, False]).all()
+    assert (get_mask(np.array([11, 21, 36, 1])) == [True, True, True, True]).all()
 
 
 def check_load_wfn(name):
@@ -161,7 +195,7 @@ def check_load_wfn(name):
     n_mo = mol1.exp_alpha.nfn
     assert (abs(mol1.exp_alpha.energies - mol2.exp_alpha.energies[:n_mo]) < 1.e-5).all()
     assert (mol1.exp_alpha.occupations == mol2.exp_alpha.occupations[:n_mo]).all()
-    assert (abs(mol1.exp_alpha.coeffs   - mol2.exp_alpha.coeffs[:,:n_mo]) < 1.e-7).all()
+    assert (abs(mol1.exp_alpha.coeffs - mol2.exp_alpha.coeffs[:, :n_mo]) < 1.e-7).all()
     # Check overlap
     olp1 = obasis1.compute_overlap(mol1.lf)
     olp2 = obasis2.compute_overlap(mol2.lf)
@@ -178,48 +212,56 @@ def check_load_wfn(name):
     charges1 = compute_mulliken_charges(obasis1, mol1.lf, numbers1, dm_full1)
     dm_full2 = mol2.get_dm_full()
     charges2 = compute_mulliken_charges(obasis2, mol2.lf, numbers2, dm_full2)
+    assert (abs(charges1 - charges2) < 1e-6).all()
     return energy1, charges1
 
 
 def test_load_wfn_he_s_virtual():
     energy, charges = check_load_wfn('he_s_virtual')
-    assert abs(energy - (-2.855160426155)) < 1.e-6     #Compare to the energy printed in wfn file
+    # Compare to the energy printed in wfn file
+    assert abs(energy - (-2.855160426155)) < 1.e-6
     assert (abs(charges - [0.0]) < 1e-5).all()
 
 
 def test_load_wfn_he_s():
     energy, charges = check_load_wfn('he_s_orbital')
-    assert abs(energy - (-2.855160426155)) < 1.e-6     #Compare to the energy printed in wfn file
+    # Compare to the energy printed in wfn file
+    assert abs(energy - (-2.855160426155)) < 1.e-6
     assert (abs(charges - [0.0]) < 1e-5).all()
 
 
 def test_load_wfn_he_sp():
     energy, charges = check_load_wfn('he_sp_orbital')
-    assert abs(energy - (-2.859895424589)) < 1.e-6     #Compare to the energy printed in wfn file
+    # Compare to the energy printed in wfn file
+    assert abs(energy - (-2.859895424589)) < 1.e-6
     assert (abs(charges - [0.0]) < 1e-5).all()
 
 
 def test_load_wfn_he_spd():
     energy, charges = check_load_wfn('he_spd_orbital')
-    assert abs(energy - (-2.855319016184)) < 1.e-6     #Compare to the energy printed in wfn file
+    # Compare to the energy printed in wfn file
+    assert abs(energy - (-2.855319016184)) < 1.e-6
     assert (abs(charges - [0.0]) < 1e-5).all()
 
 
 def test_load_wfn_he_spdf():
     energy, charges = check_load_wfn('he_spdf_orbital')
-    assert abs(energy - (-1.100269433080)) < 1.e-6   #Compare to the energy printed in wfn file
+    # Compare to the energy printed in wfn file
+    assert abs(energy - (-1.100269433080)) < 1.e-6
     assert (abs(charges - [0.0]) < 1e-5).all()
 
 
 def test_load_wfn_he_spdfgh():
     energy, charges = check_load_wfn('he_spdfgh_orbital')
-    assert abs(energy - (-1.048675168346)) < 1.e-6   #Compare to the energy printed in wfn file
+    # Compare to the energy printed in wfn file
+    assert abs(energy - (-1.048675168346)) < 1.e-6
     assert (abs(charges - [0.0]) < 1e-5).all()
 
 
 def test_load_wfn_he_spdfgh_virtual():
     energy, charges = check_load_wfn('he_spdfgh_virtual')
-    assert abs(energy - (-1.048675168346)) < 1.e-6   #Compare to the energy printed in wfn file
+    # Compare to the energy printed in wfn file
+    assert abs(energy - (-1.048675168346)) < 1.e-6
     assert (abs(charges - [0.0]) < 1e-5).all()
 
 
@@ -240,7 +282,8 @@ def check_wfn(fn_wfn, restricted, nbasis, energy, charges):
     dm_full = mol.get_dm_full()
     mycharges = compute_mulliken_charges(mol.obasis, mol.lf, mol.numbers, dm_full)
     assert (abs(charges - mycharges) < 1e-5).all()
-    return mol.obasis, mol.lf, mol.coordinates, mol.numbers, dm_full, mol.exp_alpha, getattr(mol, 'exp_beta', None)
+    exp_beta = getattr(mol, 'exp_beta', None)
+    return mol.obasis, mol.lf, mol.coordinates, mol.numbers, dm_full, mol.exp_alpha, exp_beta
 
 
 def test_load_wfn_h2o_sto3g_decontracted():
@@ -257,10 +300,13 @@ def test_load_wfn_h2_ccpvqz_virtual():
         True, 74, -1.133504568400,
         np.array([0.0, 0.0]),
     )
-    assert (abs(obasis.alphas[:5] - [82.64000, 12.41000, 2.824000, 0.7977000, 0.2581000]) < 1.e-5).all()
-    assert (exp_alpha.energies[:5] == [-0.596838, 0.144565, 0.209605, 0.460401, 0.460401]).all()
-    assert (exp_alpha.energies[-5:] == [12.859067, 13.017471, 16.405834, 25.824716, 26.100443]).all()
-    assert (exp_alpha.occupations[:5] == [1.0, 0.0, 0.0, 0.0, 0.0] ).all()
+    expect = [82.64000, 12.41000, 2.824000, 0.7977000, 0.2581000]
+    assert (abs(obasis.alphas[:5] - expect) < 1.e-5).all()
+    expect = [-0.596838, 0.144565, 0.209605, 0.460401, 0.460401]
+    assert (exp_alpha.energies[:5] == expect).all()
+    expect = [12.859067, 13.017471, 16.405834, 25.824716, 26.100443]
+    assert (exp_alpha.energies[-5:] == expect).all()
+    assert (exp_alpha.occupations[:5] == [1.0, 0.0, 0.0, 0.0, 0.0]).all()
     assert abs(exp_alpha.occupations.sum() - 1.0) < 1.e-6
 
 
@@ -279,13 +325,15 @@ def test_load_wfn_li_sp_virtual():
         np.array([0.0, 0.0])
     )
     assert abs(exp_alpha.occupations.sum() - 2.0) < 1.e-6
-    assert abs(exp_beta.occupations.sum()  - 1.0) < 1.e-6
+    assert abs(exp_beta.occupations.sum() - 1.0) < 1.e-6
     assert (exp_alpha.occupations == [1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]).all()
-    assert (exp_beta.occupations  == [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]).all()
-    assert (abs(exp_alpha.energies - [-0.087492, -0.080310, 0.158784, 0.158784, 1.078773, 1.090891, 1.090891, 49.643670]) < 1.e-6).all()
-    assert (abs(exp_beta.energies  - [-0.079905, 0.176681, 0.176681, 0.212494, 1.096631, 1.096631, 1.122821, 49.643827]) < 1.e-6).all()
+    assert (exp_beta.occupations == [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]).all()
+    expect = [-0.087492, -0.080310, 0.158784, 0.158784, 1.078773, 1.090891, 1.090891, 49.643670]
+    assert (abs(exp_alpha.energies - expect) < 1.e-6).all()
+    expect = [-0.079905, 0.176681, 0.176681, 0.212494, 1.096631, 1.096631, 1.122821, 49.643827]
+    assert (abs(exp_beta.energies - expect) < 1.e-6).all()
     assert exp_alpha.coeffs.shape == (8, 8)
-    assert exp_beta.coeffs.shape  == (8, 8)
+    assert exp_beta.coeffs.shape == (8, 8)
 
 
 def test_load_wfn_li_sp():
@@ -313,23 +361,23 @@ def test_load_wfn_o2_virtual():
         np.array([0.0, 0.0]),
     )
     assert abs(exp_alpha.occupations.sum() - 9.0) < 1.e-6
-    assert abs(exp_beta.occupations.sum()  - 7.0) < 1.e-6
+    assert abs(exp_beta.occupations.sum() - 7.0) < 1.e-6
     assert exp_alpha.occupations.shape == (44,)
-    assert exp_beta.occupations.shape  == (44,)
+    assert exp_beta.occupations.shape == (44,)
     assert (exp_alpha.occupations[:9] == np.ones(9)).all()
-    assert (exp_beta.occupations[:7]  == np.ones(7)).all()
+    assert (exp_beta.occupations[:7] == np.ones(7)).all()
     assert (exp_alpha.occupations[9:] == np.zeros(35)).all()
-    assert (exp_beta.occupations[7:]  == np.zeros(37)).all()
+    assert (exp_beta.occupations[7:] == np.zeros(37)).all()
     assert exp_alpha.energies.shape == (44,)
-    assert exp_beta.energies.shape  == (44,)
-    assert exp_alpha.energies[0]  == -20.752000
+    assert exp_beta.energies.shape == (44,)
+    assert exp_alpha.energies[0] == -20.752000
     assert exp_alpha.energies[10] == 0.179578
-    assert exp_alpha.energies[-1] ==  51.503193
-    assert exp_beta.energies[0]  == -20.697027
-    assert exp_beta.energies[15] ==  0.322590
-    assert exp_beta.energies[-1] ==  51.535258
+    assert exp_alpha.energies[-1] == 51.503193
+    assert exp_beta.energies[0] == -20.697027
+    assert exp_beta.energies[15] == 0.322590
+    assert exp_beta.energies[-1] == 51.535258
     assert exp_alpha.coeffs.shape == (72, 44)
-    assert exp_beta.coeffs.shape  == (72, 44)
+    assert exp_beta.coeffs.shape == (72, 44)
 
 
 def test_load_wfn_lif_fci():
@@ -340,20 +388,20 @@ def test_load_wfn_lif_fci():
     )
     assert exp_alpha.occupations.shape == (18,)
     assert abs(exp_alpha.occupations.sum() - 6.0) < 1.e-6
-    assert exp_alpha.occupations[0] == 2.00000000/2
-    assert exp_alpha.occupations[10] == 0.00128021/2
-    assert exp_alpha.occupations[-1] == 0.00000054/2
+    assert exp_alpha.occupations[0] == 2.00000000 / 2
+    assert exp_alpha.occupations[10] == 0.00128021 / 2
+    assert exp_alpha.occupations[-1] == 0.00000054 / 2
     assert exp_alpha.energies.shape == (18,)
     assert exp_alpha.energies[0] == -26.09321253
     assert exp_alpha.energies[15] == 1.70096290
     assert exp_alpha.energies[-1] == 2.17434072
     assert exp_alpha.coeffs.shape == (44, 18)
     kin = obasis.compute_kinetic(lf)
-    expected_kin = 106.9326884815  #FCI kinetic energy
+    expected_kin = 106.9326884815  # FCI kinetic energy
     expected_nn = 9.1130265227
     assert (kin.contract_two('ab,ab', dm_full) - expected_kin) < 1.e-6
     assert (compute_nucnuc(coordinates, numbers.astype(float)) - expected_nn) < 1.e-6
-    points = np.array([[0.0, 0.0,-0.17008], [0.0, 0.0, 0.0], [0.0, 0.0, 0.03779]])
+    points = np.array([[0.0, 0.0, -0.17008], [0.0, 0.0, 0.0], [0.0, 0.0, 0.03779]])
     density = np.zeros(3)
     obasis.compute_grid_density_dm(dm_full, points, density)
     assert (abs(density - [0.492787, 0.784545, 0.867723]) < 1.e-4).all()
@@ -366,7 +414,7 @@ def test_load_wfn_lih_cation_fci():
         np.array([0.913206, 0.086794]),
     )
     assert (numbers == [3, 1]).all()
-    expected_kin = 7.7989675958  #FCI kinetic energy
+    expected_kin = 7.7989675958  # FCI kinetic energy
     expected_nn = 0.9766607347
     kin = obasis.compute_kinetic(lf)
     assert (kin.contract_two('ab,ab', dm_full) - expected_kin) < 1.e-6

--- a/horton/io/wfn.py
+++ b/horton/io/wfn.py
@@ -78,6 +78,14 @@ def load_wfn_low(filename):
         coeffs = [i.replace('D', 'E') for i in coeffs]
         return count, occ, energy, coeffs
 
+    def helper_energy(f):
+        """Read energy."""
+        line = f.readline().lower()
+        while 'energy' not in line and line is not None:
+            line = f.readline().lower()
+        energy = float(line.split('energy =')[1].split()[0])
+        return energy
+
     # read sections of wfn file
     with open(filename) as f:
         title = f.readline().strip()
@@ -93,8 +101,9 @@ def load_wfn_low(filename):
         coefficients = np.empty([num_primitives, num_mo], float)
         for mo in xrange(num_mo):
             mo_count[mo], mo_occ[mo], mo_energy[mo], coefficients[:, mo] = helper_mo(f)
+        energy = helper_energy(f)
     return title, numbers, coordinates, centers, type_assignment, exponent, \
-        mo_count, mo_occ, mo_energy, coefficients
+        mo_count, mo_occ, mo_energy, coefficients, energy
 
 
 def get_permutation_orbital(type_assignment):
@@ -190,10 +199,10 @@ def load_wfn(filename, lf):
             expansions.
 
        **Returns:** a dictionary with ``title``, ``coordinates``, ``numbers``,
-       ``obasis`` and ``exp_alpha``. May contain ``exp_beta``.
+       ``energy``, ``obasis`` and ``exp_alpha``. May contain ``exp_beta``.
     """
     title, numbers, coordinates, centers, type_assignment, exponents, \
-        mo_count, mo_occ, mo_energy, coefficients = load_wfn_low(filename)
+        mo_count, mo_occ, mo_energy, coefficients, energy = load_wfn_low(filename)
     permutation = get_permutation_basis(type_assignment)
     # permute arrays containing wfn data
     type_assignment = type_assignment[permutation]
@@ -249,6 +258,7 @@ def load_wfn(filename, lf):
         'lf': lf,
         'numbers': numbers,
         'obasis': obasis,
+        'energy': energy,
     }
     if exp_beta is not None:
         result['exp_beta'] = exp_beta

--- a/horton/io/wfn.py
+++ b/horton/io/wfn.py
@@ -18,44 +18,46 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 #
 # --
-'''WFN File format (Gaussian and GAMESS)'''
+"""WFN File format (Gaussian and GAMESS)"""
 
 
 import numpy as np
 from horton.periodic import periodic
+from horton.gbasis.gobasis import GOBasis
 
 
-__all__ = ['load_wfn_low', 'setup_permutation1', 'setup_permutation2', 'setup_mask', 'load_wfn']
+__all__ = ['load_wfn_low', 'get_permutation_orbital',
+           'get_permutation_basis', 'get_mask', 'load_wfn']
 
 
 def load_wfn_low(filename):
-    '''Load data from a WFN file into arrays
+    """Load data from a WFN file into arrays.
 
        **Arguments:**
 
        filename
             The filename of the wfn file.
-    '''
+    """
 
     def helper_num(f):
-        '''Reads number of orbitals, primitives and atoms'''
+        """Read number of orbitals, primitives and atoms."""
         line = f.readline()
         assert line.startswith('GAUSSIAN')
         return [int(i) for i in line.split() if i.isdigit()]
 
     def helper_coordinates(f):
-        '''Reads the coordiantes of the atoms'''
+        """Read the coordiantes of the atoms."""
         numbers = np.empty(num_atoms, int)
         coordinates = np.empty((num_atoms, 3), float)
         for atom in xrange(num_atoms):
             line = f.readline()
             line = line.split()
             numbers[atom] = periodic[line[0]].number
-            coordinates[atom,:] = [line[4], line[5], line[6]]
+            coordinates[atom, :] = [line[4], line[5], line[6]]
         return numbers, coordinates
 
     def helper_section(f, start, skip):
-        '''Reads CENTRE ASSIGNMENTS, TYPE ASSIGNMENTS, and EXPONENTS sections'''
+        """Read CENTRE ASSIGNMENTS, TYPE ASSIGNMENTS, and EXPONENTS sections."""
         section = []
         while len(section) < num_primitives:
             line = f.readline()
@@ -66,7 +68,7 @@ def load_wfn_low(filename):
         return section
 
     def helper_mo(f):
-        '''Reads all MO information'''
+        """Read one section of MO information."""
         line = f.readline()
         assert line.startswith('MO')
         line = line.split()
@@ -76,102 +78,107 @@ def load_wfn_low(filename):
         coeffs = [i.replace('D', 'E') for i in coeffs]
         return count, occ, energy, coeffs
 
+    # read sections of wfn file
     with open(filename) as f:
         title = f.readline().strip()
-        #Reading the wfn file
         num_mo, num_primitives, num_atoms = helper_num(f)
         numbers, coordinates = helper_coordinates(f)
-        centers = helper_section(f, 'CENTRE ASSIGNMENTS', 2)
-        centers = np.array([int(i) for i in centers]) - 1  #horton counts centers from zero!
-        type_assignment = helper_section(f, 'TYPE ASSIGNMENTS', 2)
-        type_assignment = np.array([int(i) for i in type_assignment])
-        exponents = helper_section(f, 'EXPONENTS', 1)
-        #Making arrays to store the wfn data
-        exponents = np.array([float(i.replace('D', 'E')) for i in exponents])
+        # centers are indexed from zeron in HORTON
+        centers = np.array([int(i) - 1 for i in helper_section(f, 'CENTRE ASSIGNMENTS', 2)])
+        type_assignment = np.array([int(i) for i in helper_section(f, 'TYPE ASSIGNMENTS', 2)])
+        exponent = np.array([float(i.replace('D', 'E')) for i in helper_section(f, 'EXPONENTS', 1)])
         mo_count = np.empty(num_mo, int)
         mo_occ = np.empty(num_mo, float)
         mo_energy = np.empty(num_mo, float)
         coefficients = np.empty([num_primitives, num_mo], float)
         for mo in xrange(num_mo):
             mo_count[mo], mo_occ[mo], mo_energy[mo], coefficients[:, mo] = helper_mo(f)
-        line = f.readline()
-    return title, numbers, coordinates, centers, type_assignment, exponents, \
+    return title, numbers, coordinates, centers, type_assignment, exponent, \
         mo_count, mo_occ, mo_energy, coefficients
 
 
-def setup_permutation1(type_assignment):
-    '''Permutes each type of orbital to get the proper order for HORTON'''
-    num_primitives = type_assignment.size
-    permutation = np.arange(num_primitives)
-    degeneracy = {1:1, 2:3, 5:6, 11:10, 23:15, 36:21}   # degeneracy of {s:1, p:3, d:6, f:10, g:15, h:21}
+def get_permutation_orbital(type_assignment):
+    """Permute each type of orbital to get the proper order for HORTON."""
+    num_primitive = len(type_assignment)
+    permutation = np.arange(num_primitive)
+    # degeneracy of {s:1, p:3, d:6, f:10, g:15, h:21}
+    degeneracy = {1: 1, 2: 3, 5: 6, 11: 10, 23: 15, 36: 21}
     index = 0
-    while index < num_primitives:
+    while index < num_primitive:
         value = type_assignment[index]
         length = degeneracy[value]
-        if value != 1 and value == type_assignment[index+1]:
+        if value != 1 and value == type_assignment[index + 1]:
             sub_count = 1
-            while index + sub_count < num_primitives and type_assignment[index + sub_count] == value:
+            while index + sub_count < num_primitive and type_assignment[index + sub_count] == value:
                 sub_count += 1
             sub_type = np.empty(sub_count, int)
-            sub_type[:] = permutation[index : index + sub_count]
+            sub_type[:] = permutation[index: index + sub_count]
             for i in xrange(sub_count):
-                permutation[index : index + length] = sub_type[i] + np.arange(length)*sub_count
+                permutation[index: index + length] = sub_type[i] + np.arange(length) * sub_count
                 index += length
         else:
             index += length
-    assert (np.sort(permutation) == np.arange(num_primitives)).all()
+    assert (np.sort(permutation) == np.arange(num_primitive)).all()
     return permutation
 
 
-def setup_permutation2(type_assignment):
-    '''Permutes the basis functions to get the proper order for HORTON
+def get_permutation_basis(type_assignment):
+    """
+    Permute the basis functions to get the proper order for HORTON.
 
-       Permutation conventions are as follows::
+    Permutation conventions are as follows:
 
-           d orbitals:
-               wfn:     [5, 6, 7, 8, 9, 10]
-               HORTON:  [5, 8, 9, 6, 10, 7]
-               permute: [0, 3, 4, 1, 5, 2]
+     d orbitals:
+       wfn:     [5, 6, 7, 8, 9, 10]
+       HORTON:  [5, 8, 9, 6, 10, 7]
+       permute: [0, 3, 4, 1, 5, 2]
 
-           f orbitals:
-               wfn:     [11, 12, 13, 17, 14, 15, 18, 19, 16, 20]
-               HORTON:  [11, 14, 15, 17, 20, 18, 12, 16, 19, 13]
-               permute: [0, 4, 5, 3, 9, 6, 1, 8, 7, 2]
+     f orbitals:
+       wfn:     [11, 12, 13, 17, 14, 15, 18, 19, 16, 20]
+       HORTON:  [11, 14, 15, 17, 20, 18, 12, 16, 19, 13]
+       permute: [0, 4, 5, 3, 9, 6, 1, 8, 7, 2]
 
-           g orbital:
-               wfn:     [23, 29, 32, 27, 22, 28, 35, 34, 26, 31, 33, 30, 25, 24, 21]
-               HORTON:  [21, 24, 25, 30, 33, 31, 26, 34, 35, 28, 22, 27, 32, 29, 23]
-               permute: [14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+     g orbital:
+       wfn:     [23, 29, 32, 27, 22, 28, 35, 34, 26, 31, 33, 30, 25, 24, 21]
+       HORTON:  [21, 24, 25, 30, 33, 31, 26, 34, 35, 28, 22, 27, 32, 29, 23]
+       permute: [14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
 
-           h orbital:
-               wfn:     [36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56]
-               HORTON:  [56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36]
-               permute: [20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
-    '''
-    num_primitives = type_assignment.size
-    permutation = setup_permutation1(type_assignment)
+     h orbital:
+       wfn:     [36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56]
+       HORTON:  [56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36]
+       permute: [20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
+    """
+    permutation = get_permutation_orbital(type_assignment)
     type_assignment = type_assignment[permutation]
     for count, value in enumerate(type_assignment):
-        if value == 5:     #d-orbitals
-            permutation[count: count+6] = permutation[count: count+6][[0, 3, 4, 1, 5, 2]]
-        elif value == 11:  #f-orbitals
-            permutation[count: count+10] = permutation[count: count+10][[0, 4, 5, 3, 9, 6, 1, 8, 7, 2]]
-        elif value == 23:  #g-orbitals
-            permutation[count: count+15] = permutation[count:count+15][[14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]]
-        elif value == 36:  #h-orbitals
-            permutation[count: count+21] = permutation[count: count+21][::-1]
+        if value == 5:
+            # d-orbitals
+            permute = [0, 3, 4, 1, 5, 2]
+            permutation[count: count + 6] = permutation[count: count + 6][permute]
+        elif value == 11:
+            # f-orbitals
+            permute = [0, 4, 5, 3, 9, 6, 1, 8, 7, 2]
+            permutation[count: count + 10] = permutation[count: count + 10][permute]
+        elif value == 23:
+            # g-orbitals
+            permute = [14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+            permutation[count: count + 15] = permutation[count:count + 15][permute]
+        elif value == 36:
+            # h-orbitals
+            permutation[count: count + 21] = permutation[count: count + 21][::-1]
     return permutation
 
 
-def setup_mask(type_assignment):
-    '''Masking orbital types other than s, the_first_p, the_first_d, the_first_f, the_first_g, the_first _h'''
-    temp = [1, 2, 5, 11, 21, 36] #index of the [s, the_first_p, the_first_d, the_first_f, the_first_g, the_first_h]
-    mask = [i in temp for i in type_assignment]
-    return np.array(mask)
+def get_mask(type_assignment):
+    """Return array to mask orbital types other than s, 1st_p, 1st_d, 1st_f, 1st_g, 1st_h."""
+    # index of [s, 1st_p, 1st_d, 1st_f, 1st_g, 1st_h]
+    temp = [1, 2, 5, 11, 21, 36]
+    mask = np.array([i in temp for i in type_assignment])
+    return mask
 
 
 def load_wfn(filename, lf):
-    '''Load data from a WFN file
+    """Load data from a WFN file.
 
        **Arguments:**
 
@@ -184,54 +191,54 @@ def load_wfn(filename, lf):
 
        **Returns:** a dictionary with ``title``, ``coordinates``, ``numbers``,
        ``obasis`` and ``exp_alpha``. May contain ``exp_beta``.
-    '''
+    """
     title, numbers, coordinates, centers, type_assignment, exponents, \
         mo_count, mo_occ, mo_energy, coefficients = load_wfn_low(filename)
-    permutation = setup_permutation2(type_assignment)
-    #Permuting the arrays containing the wfn data
+    permutation = get_permutation_basis(type_assignment)
+    # permute arrays containing wfn data
     type_assignment = type_assignment[permutation]
-    mask = setup_mask(type_assignment)
+    mask = get_mask(type_assignment)
     reduced_size = np.array(mask, int).sum()
     num_mo = coefficients.shape[1]
     alphas = np.empty(reduced_size)
     alphas[:] = exponents[permutation][mask]
     assert (centers == centers[permutation]).all()
     shell_map = centers[mask]
-    shell = {1:0, 2:1, 5:2, 11:3, 21:4, 36:5} #Cartesian: {S:0, P:1, D:2, F:3, G:4, H:5}
+    # cartesian basis: {S:0, P:1, D:2, F:3, G:4, H:5}
+    shell = {1: 0, 2: 1, 5: 2, 11: 3, 21: 4, 36: 5}
     shell_types = type_assignment[mask]
     shell_types = np.array([shell[i] for i in shell_types])
     assert shell_map.size == shell_types.size == reduced_size
     nprims = np.ones(reduced_size, int)
     con_coeffs = np.ones(reduced_size)
-    #Building the basis set
-    from horton.gbasis.gobasis import GOBasis
+    # build basis set
     obasis = GOBasis(coordinates, shell_map, nprims, shell_types, alphas, con_coeffs)
     if lf.default_nbasis is not None and lf.default_nbasis != obasis.nbasis:
-        raise TypeError('The value of lf.default_nbasis does not match nbasis reported in the wfn file.')
+        raise TypeError(
+            'The value of lf.default_nbasis does not match nbasis reported in the wfn file.')
     lf.default_nbasis = obasis.nbasis
     coefficients = coefficients[permutation]
-    coefficients /= obasis.get_scales().reshape(-1,1)
-    #Making the wavefunction:
+    coefficients /= obasis.get_scales().reshape(-1, 1)
+    # make the wavefunction
     if mo_occ.max() > 1.0:
-        #close shell system
-        nelec = int(round(mo_occ.sum()))
+        # close shell system
         exp_alpha = lf.create_expansion(obasis.nbasis, coefficients.shape[1])
         exp_alpha.coeffs[:] = coefficients
         exp_alpha.energies[:] = mo_energy
-        exp_alpha.occupations[:] = mo_occ/2
+        exp_alpha.occupations[:] = mo_occ / 2
         exp_beta = None
     else:
-        #open shell system
-        #counting the number of alpha and beta orbitals
+        # open shell system
+        # counting the number of alpha and beta orbitals
         index = 1
-        while index < num_mo and mo_energy[index] >= mo_energy[index-1] and mo_count[index] == mo_count[index-1]+1:
+        while index < num_mo and mo_energy[index] >= mo_energy[index - 1] and mo_count[index] == mo_count[index - 1] + 1:
             index += 1
         exp_alpha = lf.create_expansion(obasis.nbasis, index)
-        exp_alpha.coeffs[:] = coefficients[:,:index]
+        exp_alpha.coeffs[:] = coefficients[:, :index]
         exp_alpha.energies[:] = mo_energy[:index]
         exp_alpha.occupations[:] = mo_occ[:index]
-        exp_beta = lf.create_expansion(obasis.nbasis, num_mo-index)
-        exp_beta.coeffs[:] = coefficients[:,index:]
+        exp_beta = lf.create_expansion(obasis.nbasis, num_mo - index)
+        exp_beta.coeffs[:] = coefficients[:, index:]
         exp_beta.energies[:] = mo_energy[index:]
         exp_beta.occupations[:] = mo_occ[index:]
 


### PR DESCRIPTION
The main purpose of this pull request is to have WFN reader load the energy alongside the wave-function information from WFN files. Having energy is important for `ChemTools` when users want to compute conceptual DFT reactivity descriptors using WFN files.

In summary:
1. The `io/wfn.py` module was updated & tested to load energy from the last line of WFN files.
2. The `doc/tech_ref_file_formats.rst` file was updated to have energy as an always loading attribute.
3. The `io/wfn.py` was improved to better follow PEP8 guidelines (the corresponding `test_wfn.py` was also improved to help with readability).