### PR TITLE
Fix sphinx python version

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS        =
-SPHINXBUILD       = PYTHONPATH=../:./:$(PYTHONPATH) sphinx-build
+SPHINXBUILD       = PYTHONPATH=../:./:$(PYTHONPATH) sphinx-build-2
 SPHINXAUTOBUILD   = PYTHONPATH=../:./:$(PYTHONPATH) sphinx-autobuild
 PAPER             =
 BUILDDIR          = _build


### PR DESCRIPTION
Somehow the new version of sphinx-build defaults to python 3. Maybe pip changed their behaviour. This forces it to use python 2. Fixes #227 