### PR TITLE
removed requirement for print statements

### DIFF
--- a/doc/tech_dev_checklist.rst
+++ b/doc/tech_dev_checklist.rst
@@ -414,6 +414,10 @@ The following is disabled to allow access to the protected members of the
   a protected member (i.e. class member with a name beginning with an underscore) is
   access outside the class or a descendant of the class where it’s defined.
 
+The following is disabled to allow for ease of splitting modules (i.e. modularity):
+
+* **W0403**: relative imports. Relative import %r, should be %r
+
 The following are excluded due false positives:
 
 * **E0611**: *no-name-in-module*. No name %r in module %r used when a name cannot be found

--- a/tools/qa/check_commits.py
+++ b/tools/qa/check_commits.py
@@ -140,10 +140,6 @@ def check_commits(ancestor):
                     if line.endswith(' '):
                         print '      Trailing whitespace   {}'.format(location)
                         result = 1
-                    if new_filename.startswith('horton') and ' print' in line and \
-                       ('horton/io' not in new_filename):
-                        print '      print command         {}'.format(location)
-                        result = 1
                     line_number += 1
                 elif line.startswith(' '):
                     line_number += 1

--- a/tools/qa/pylintrc
+++ b/tools/qa/pylintrc
@@ -59,7 +59,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=I0020,I0021,W0704,E0611,E1101,C0103,C0326,W0212,I0011,R0201,C0411,W0613,W0621,E1136,W0221,W0223,W0511
+disable=I0020,I0021,W0704,E0611,E1101,C0103,C0326,W0212,I0011,R0201,C0411,W0613,W0621,E1136,W0221,W0223,W0511,W0403
 #disable=all
 
 [REPORTS]


### PR DESCRIPTION
Remove the check for print statements. 

Maybe we should replace it with something like "make sure 'x:' is in the print statement though, where x is a number.