### PR TITLE
Update libxc citation

### DIFF
--- a/data/references.bib
+++ b/data/references.bib
@@ -303,6 +303,18 @@
     author = {Miguel A.L. Marques and Micael J.T. Oliveira and Tobias Burnus},
 }
 
+@article{lehtola2018,
+    title = "Recent developments in libxc -- A comprehensive library of functionals for density functional theory",
+    journal = "SoftwareX",
+    volume = "7",
+    pages = "1 - 5",
+    year = "2018",
+    issn = "2352-7110",
+    doi = "https://doi.org/10.1016/j.softx.2017.11.002",
+    url = "http://www.sciencedirect.com/science/article/pii/S2352711017300602",
+    author = "Susi Lehtola and Conrad Steigemann and Micael J.T. Oliveira and Miguel A.L. Marques",
+}
+
 @article{verstraelen2012a,
     author = {Verstraelen, T. and Ayers, P. W. and Van Speybroeck, V. and Waroquier, M.},
     doi = {10.1016/j.cplett.2012.07.028},

--- a/doc/intro_horton_overview.rst
+++ b/doc/intro_horton_overview.rst
@@ -81,7 +81,7 @@ Main Features
 
 * Integrating the `LibXC
   <http://www.tddft.org/programs/octopus/wiki/index.php/Libxc>`_
-  [marques2012]_ and `LibInt2 <https://github.com/evaleev/libint>`_
+  [lehtola2018]_ and `LibInt2 <https://github.com/evaleev/libint>`_
   [valeev2014]_ libraries.
 
 * Supporting many :ref:`ref_file_formats` to exchange data with other codes.

--- a/doc/intro_horton_overview.rst
+++ b/doc/intro_horton_overview.rst
@@ -107,7 +107,7 @@ Main Features
 
     * Restricted and unrestricted orbitals
 
-    * LDA, GGA and Hybrid GGA :ref:`ref_functionals`
+    * LDA, GGA, hybrid GGA, mGGA, and hybrid mGGA :ref:`ref_functionals`
 
     * Various SCF algorithms
 

--- a/doc/tech_dev_checklist.rst
+++ b/doc/tech_dev_checklist.rst
@@ -661,7 +661,7 @@ When no source is mentioned, the criteria are specific to HORTON.
       ``[lastnameyear]_``
 
     * **MP0403** Add ``log.cite('someref', 'a reason')`` to the code based on the
-      publication, e.g. ``log.cite('marques2012', 'using LibXC, the library of exchange
+      publication, e.g. ``log.cite('lehtola2018', 'using LibXC, the library of exchange
       and correlation functionals').``
 
     * **MP0404** No begging for citations in the output or documentation. Go beyond

--- a/doc/tech_dev_citing_papers.rst
+++ b/doc/tech_dev_citing_papers.rst
@@ -32,6 +32,6 @@ properly:
    touch existing references if not needed.
 
 2. Add ``log.cite('someref', 'a reason')`` to the code based on the publication, e.g.\
-   ``log.cite('marques2012', 'using LibXC, the library of exchange and correlation functionals')``.
+   ``log.cite('lehtola2018', 'using LibXC, the library of exchange and correlation functionals')``.
    This guarantees that paper is properly cited at the end of the HORTON screen
    output.

--- a/doc/update_functionals.py
+++ b/doc/update_functionals.py
@@ -88,7 +88,7 @@ def main():
     print >> s, 'The following functionals are available in HORTON through `LibXC'
     print >> s, '<http://www.tddft.org/programs/octopus/wiki/index.php/Libxc>`_ %s.' % \
         libxc_version
-    print >> s, '[marques2012]_'
+    print >> s, '[lehtola2018]_'
     print >> s
     for key in keys:
         try:

--- a/horton/meanfield/libxc.py
+++ b/horton/meanfield/libxc.py
@@ -56,7 +56,7 @@ class LibXCEnergy(GridObservable):
         name = '%s_%s' % (self.prefix, name)
         self._name = name
         self._libxc_wrapper = self.LibXCWrapper(name)
-        biblio.cite('marques2012', 'using LibXC, the library of exchange and correlation functionals')
+        biblio.cite('lehtola2018', 'using LibXC, the library of exchange and correlation functionals')
         GridObservable.__init__(self, 'libxc_%s' % name)
 
 


### PR DESCRIPTION
The manual has an obsolete citation to Libxc. This PR brings the citation up to date.