### PR TITLE
fix install bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ qaworkdir
 
 # Ignore Pycharm
 .idea
+
+*.egg-info/
+record.txt

--- a/horton/gbasis/ints.cpp
+++ b/horton/gbasis/ints.cpp
@@ -506,7 +506,7 @@ void GB4Integral::cart_to_pure() {
 #error LibInt must be compiled with support for electron repulsion integrals.
 #endif
 
-#if LIBINT2_MAX_AM_eri < MAX_SHELL_TYPE
+#if LIBINT2_MAX_AM_ERI < MAX_SHELL_TYPE
 #error LibInt must be compiled with an angular momentum limit of at least MAX_SHELL_TYPE.
 #endif
 

--- a/tools/qa/install_libxc-3.0.0.sh
+++ b/tools/qa/install_libxc-3.0.0.sh
@@ -10,7 +10,11 @@ if [ ! -d "${CACHED}/${NAMEVER}/lib" ]; then
     cd ${QAWORKDIR}
     mkdir -p depbuild
     cd depbuild
-    curl -OL "http://www.tddft.org/programs/libxc/down.php?file=${VER}/${NAMEVER}.tar.gz"
+    if [ "$VER" = "3.0.0" ]; then
+        curl -OL "https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/libxc/3.0.0-1build1/libxc_3.0.0.orig.tar.gz"
+    else
+        curl -OL "http://www.tddft.org/programs/libxc/down.php?file=${VER}/${NAMEVER}.tar.gz"
+    fi
     tar -xzf ${NAMEVER}.tar.gz
     cd ${NAMEVER}
     echo "Actual build and install. This may take a while."


### PR DESCRIPTION
There are two bugs when installing Horton with Python3 using `./setup.py install`:

- The `libint-2.0.3` library: `#if LIBINT2_MAX_AM_eri < MAX_SHELL_TYPE` should be `#if LIBINT2_MAX_AM_ERI < MAX_SHELL_TYPE` in `/horton/gbasis/ints.cpp`.

- Downloading `libxc-3.0.0` from the official website is currently not available. However, one can download it from this source: https://src.fedoraproject.org/lookaside/extras/libxc/.

Other known issues:

- Some tests fail when using `libxc-3.0.0`, such as the `m05` functional.