### PR TITLE
Fix reference atoms Makefile

### DIFF
--- a/data/refatoms/Makefile
+++ b/data/refatoms/Makefile
@@ -1,8 +1,8 @@
 all: 001__H_N01_M2.h5
 
-refatoms.tar.bz2:
-	curl -O http://users.ugent.be/~tovrstra/horton/refatoms.tar.bz2
+refatoms.tar.gz:
+	curl -O https://users.ugent.be/~tovrstra/horton/refatoms.tar.gz
 
-001__H_N01_M2.h5: refatoms.tar.bz2 fixformat.py
-	tar -xjf refatoms.tar.bz2
+001__H_N01_M2.h5: refatoms.tar.gz fixformat.py
+	tar -xzf refatoms.tar.gz
 	python ./fixformat.py


### PR DESCRIPTION
The reference atoms were uploaded again to their original location. Minor changes were needed to make the Makefile work.